### PR TITLE
Dut_Logger

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,5 @@ cmake-build-*/
 
 # IntelliJ
 out/
+
+Sim_To_DuT_Interface/logs/

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,6 @@
 [submodule "Dummy_DuT/REST_Dummy_DuT/restbed"]
 	path = Dummy_DuT/REST_Dummy_DuT/restbed
 	url = https://github.com/Corvusoft/restbed.git
+[submodule "Sim_To_DuT_Interface/DuTLogger/quill"]
+	path = Sim_To_DuT_Interface/DuTLogger/quill
+	url = https://github.com/odygrd/quill.git

--- a/Sim_To_DuT_Interface/CMakeLists.txt
+++ b/Sim_To_DuT_Interface/CMakeLists.txt
@@ -1,7 +1,9 @@
 cmake_minimum_required(VERSION 3.20)
 project(Sim_To_DuT_Interface)
 
-set(CMAKE_CXX_STANDARD 20)
+set(CMAKE_CXX_STANDARD 17)
+
+add_subdirectory(DuTLogger/quill/quill)
 
 add_executable(Sim_To_DuT_Interface main.cpp
         DuT_Connectors/DuT_Connector.cpp DuT_Connectors/DuT_Connector.h
@@ -10,4 +12,8 @@ add_executable(Sim_To_DuT_Interface main.cpp
         DuT_Connectors/REST_Dummy_Connector/Rest_Dummy_Connector.cpp
         DuT_Connectors/REST_Dummy_Connector/Rest_Dummy_Connector.h
         DuT_Connectors/CAN_Connector/CAN_Connector.cpp DuT_Connectors/CAN_Connector/CAN_Connector.h
-        DuT_Connectors/DuT_Info.cpp DuT_Connectors/DuT_Info.h)
+        DuT_Connectors/DuT_Info.cpp DuT_Connectors/DuT_Info.h
+        DuTLogger/DuTLogger.h
+        DuTLogger/DuTLogger.cpp)
+
+target_link_libraries(${PROJECT_NAME} PRIVATE quill::quill)

--- a/Sim_To_DuT_Interface/DuTLogger/DuTLogger.cpp
+++ b/Sim_To_DuT_Interface/DuTLogger/DuTLogger.cpp
@@ -1,0 +1,214 @@
+//
+// Created by marco on 26.10.21.
+//
+
+#include "DuTLogger.h"
+
+// initialize the static handlers
+quill::Handler* DuTLogger::consoleHandler = DuTLogger::buildConsoleHandler();
+quill::Handler* DuTLogger::consoleFileHandler = DuTLogger::buildFileHandler();
+
+// initialize the static loggers
+quill::Logger* DuTLogger::consoleLogger = DuTLogger::createConsoleLogger("consoleLog", false);
+quill::Logger* DuTLogger::consoleFileLogger = DuTLogger::createConsoleLogger("consoleFileLog", true);
+quill::Logger* DuTLogger::dataLogger = DuTLogger::createDataLogger();
+
+quill::Logger* DuTLogger::createConsoleLogger(const char* name, bool withFileHandler) {
+    // check if the quill engine is started
+    startEngine();
+
+    // check if the new logger needs to write the console log to a file
+    // if it needs it, we have to build the logger a different way
+    quill::Logger* newLogger;
+    if (withFileHandler) {
+        newLogger = quill::create_logger(name, {consoleHandler, consoleFileHandler});
+    } else {
+        newLogger = quill::create_logger(name, consoleHandler);
+    }
+
+    // Set the LogLevel (L3 for everything)
+    newLogger->set_log_level(quill::LogLevel::TraceL3);
+
+    return newLogger;
+}
+
+void DuTLogger::startEngine() {
+    // start the quill engine if it hasn't been started yet
+    if (!startedQuillEngine) {
+        quill::enable_console_colours();
+        quill::start();
+
+        // remember that we started the engine
+        startedQuillEngine = true;
+    }
+}
+
+quill::Handler* DuTLogger::buildConsoleHandler() {
+    // build a handler for the console
+    quill::Handler* newHandler = consoleHandler = quill::stdout_handler("consoleHandler");
+    newHandler->set_log_level(DEFAULT_CONSOLE_LOG_LEVEL);
+
+    // modify the pattern for the logger
+    newHandler->set_pattern(QUILL_STRING("%(ascii_time)  %(level_name): %(message)"),
+                                "%D %H:%M:%S.%Qms");
+    return newHandler;
+}
+
+quill::Handler* DuTLogger::buildFileHandler() {
+    // get the path to the log file or create the directory if necessary
+    std::string path = DuTLogger::getLoggingPath(LOGGER_TYP::CONSOLE);
+    createDirectoryIfNecessary(path);
+
+    // a second handler for the file is needed
+    quill::Handler* newHandler = quill::file_handler(path.append("/Logfile.log"), "w");
+    newHandler->set_log_level(DEFAULT_FILE_LOG_LEVEL);
+
+    // modify the pattern for the logger
+    newHandler->set_pattern(QUILL_STRING("%(ascii_time)  %(level_name): %(message)"),
+                            "%D %H:%M:%S.%Qms");
+
+    return newHandler;
+}
+
+quill::Logger* DuTLogger::createDataLogger() {
+    // get the path to the log file or create the directory if necessary
+    std::string path = DuTLogger::getLoggingPath(LOGGER_TYP::DATA);
+    createDirectoryIfNecessary(path);
+
+    // create a file handler to connect quill to a logfile
+    quill::Handler* file_handler = quill::file_handler(path.append("/Logfile.log"), "w");
+
+    // configure the pattern of a line
+    file_handler->set_pattern(QUILL_STRING("%(ascii_time) %(logger_name) - %(message)"),
+            "%D %H:%M:%S.%Qms %z", quill::Timezone::LocalTime);
+
+    // finally, create the logger and return it
+    quill::Logger* createdLogger = quill::create_logger("dataLog", file_handler);
+
+    return createdLogger;
+}
+
+std::string DuTLogger::getLoggingPath(LOGGER_TYP typ) {
+    // get the path, where this program is running
+    std::string path = std::filesystem::current_path();
+
+    // modify the path, so it leads to our logfile
+    std::string result = path.substr(0, path.find_last_of("/"));
+
+    // get the right path for the logger
+    if (typ == LOGGER_TYP::DATA) {
+        result.append(PATH_DATA_LOG);
+    } else {
+        result.append(PATH_CONSOLE_LOG);
+    }
+    // return the path
+    return result;
+}
+
+void DuTLogger::createDirectoryIfNecessary(const std::string path) {
+    // check if the directory is created in the file system
+    std::filesystem::create_directories(path);
+}
+
+void DuTLogger::disableConsoleToFileLogging(bool disable) {
+    enableConsoleToFile = !disable;
+}
+
+void DuTLogger::changeLogLevel(LOG_LEVEL_CHANGE_ON typ, LOG_LEVEL level) {
+    quill::Handler* handler = DuTLogger::getHandlerTyp(typ);
+
+    switch (level) {
+        case LOG_LEVEL::NONE:
+            handler->set_log_level(quill::LogLevel::None);
+            break;
+
+        case LOG_LEVEL::DEBUG:
+            handler->set_log_level(quill::LogLevel::Debug);
+            break;
+
+        case LOG_LEVEL::INFO:
+            handler->set_log_level(quill::LogLevel::Info);
+            break;
+
+        case LOG_LEVEL::WARNING:
+            handler->set_log_level(quill::LogLevel::Warning);
+            break;
+
+        case LOG_LEVEL::ERROR:
+            handler->set_log_level(quill::LogLevel::Error);
+            break;
+
+        case LOG_LEVEL::CRITICAL:
+            handler->set_log_level(quill::LogLevel::Critical);
+            break;
+
+        default:
+            logMessage("Can not change LogLevel! Invalid argument!", LOG_LEVEL::ERROR);
+            handler->set_log_level(quill::LogLevel::TraceL3);
+            break;
+    }
+}
+
+quill::Handler* DuTLogger::getHandlerTyp(LOG_LEVEL_CHANGE_ON typ) {
+    quill::Handler* handler;
+
+    switch (typ) {
+        case LOG_LEVEL_CHANGE_ON::CONSOLE_LOG:
+            handler = consoleHandler;
+            break;
+
+        case LOG_LEVEL_CHANGE_ON::FILE_LOG:
+            handler = consoleFileHandler;
+            break;
+
+        default:
+            throw std::invalid_argument("Internal Error! Unknown Typ of <LOG_LEVEL_CHANGED_ON> appeared.");
+    }
+
+    return handler;
+}
+
+void DuTLogger::logMessage(std::string msg, LOG_LEVEL level) {
+    // check for the right logger
+    quill::Logger* log;
+    if (enableConsoleToFile) {
+        log = consoleFileLogger;
+    } else {
+        log = consoleLogger;
+    }
+
+    // log the msg with the specific logger
+    logWithLevel(log, msg, level);
+}
+
+void DuTLogger::logWithLevel(quill::Logger* log, std::string msg, LOG_LEVEL level) {
+    // parse the message to the right will logger with the given level
+    switch (level) {
+        case LOG_LEVEL::NONE:
+            LOG_WARNING(log, "Can't log this message, because the chosen Log_Level is <NONE>");
+            break;
+
+        case LOG_LEVEL::DEBUG:
+            LOG_DEBUG(log, "{}", msg);
+            break;
+
+        case LOG_LEVEL::INFO:
+            LOG_INFO(log, "{}", msg);
+            break;
+
+        case LOG_LEVEL::WARNING:
+            LOG_WARNING(log, "{}", msg);
+            break;
+
+        case LOG_LEVEL::ERROR:
+            LOG_ERROR(log, "{}", msg);
+            break;
+
+        case LOG_LEVEL::CRITICAL:
+            LOG_CRITICAL(log, "{}", msg);
+            break;
+
+        default:
+            throw std::invalid_argument("Parsed unknown LOG_LEVEL <" + msg + ">");
+    }
+}

--- a/Sim_To_DuT_Interface/DuTLogger/DuTLogger.cpp
+++ b/Sim_To_DuT_Interface/DuTLogger/DuTLogger.cpp
@@ -71,7 +71,7 @@ quill::Handler* DuTLogger::buildFileHandler() {
     createDirectoryIfNecessary(path);
 
     // a second handler for the file is needed
-    quill::Handler* newHandler = quill::file_handler(path.append("/Logfile.log"), "w");
+    quill::Handler* newHandler = quill::file_handler(path.append("/Logfile.log"), FILE_MODE_CONSOLE);
     newHandler->set_log_level(DEFAULT_FILE_LOG_LEVEL);
 
     // modify the pattern for the logger
@@ -87,7 +87,7 @@ quill::Logger* DuTLogger::createDataLogger() {
     createDirectoryIfNecessary(path);
 
     // create a file handler to connect quill to a logfile
-    quill::Handler* file_handler = quill::file_handler(path.append("/Logfile.log"), "w");
+    quill::Handler* file_handler = quill::file_handler(path.append("/Logfile.log"), FILE_MODE_DATA);
 
     // configure the pattern of a line
     file_handler->set_pattern(QUILL_STRING("%(ascii_time) %(logger_name) - %(message)"),

--- a/Sim_To_DuT_Interface/DuTLogger/DuTLogger.cpp
+++ b/Sim_To_DuT_Interface/DuTLogger/DuTLogger.cpp
@@ -110,10 +110,6 @@ void DuTLogger::createDirectoryIfNecessary(const std::string path) {
     std::filesystem::create_directories(path);
 }
 
-void DuTLogger::disableConsoleToFileLogging(bool disable) {
-    enableConsoleToFile = !disable;
-}
-
 void DuTLogger::changeLogLevel(LOG_LEVEL_CHANGE_ON typ, LOG_LEVEL level) {
     quill::Handler* handler = DuTLogger::getHandlerTyp(typ);
 
@@ -143,7 +139,7 @@ void DuTLogger::changeLogLevel(LOG_LEVEL_CHANGE_ON typ, LOG_LEVEL level) {
             break;
 
         default:
-            logMessage("Can not change LogLevel! Invalid argument!", LOG_LEVEL::ERROR);
+            logMessage("Can not change LogLevel! Invalid argument!", LOG_LEVEL::ERROR, true);
             handler->set_log_level(quill::LogLevel::TraceL3);
             break;
     }
@@ -168,17 +164,13 @@ quill::Handler* DuTLogger::getHandlerTyp(LOG_LEVEL_CHANGE_ON typ) {
     return handler;
 }
 
-void DuTLogger::logMessage(std::string msg, LOG_LEVEL level) {
-    // check for the right logger
-    quill::Logger* log;
-    if (enableConsoleToFile) {
-        log = consoleFileLogger;
+void DuTLogger::logMessage(std::string msg, LOG_LEVEL level, bool writeToFile) {
+    // check if we have to write the message to the LogFile
+    if (writeToFile) {
+        logWithLevel(consoleFileLogger, msg, level);
     } else {
-        log = consoleLogger;
+        logWithLevel(consoleLogger, msg, level);
     }
-
-    // log the msg with the specific logger
-    logWithLevel(log, msg, level);
 }
 
 void DuTLogger::logWithLevel(quill::Logger* log, std::string msg, LOG_LEVEL level) {

--- a/Sim_To_DuT_Interface/DuTLogger/DuTLogger.h
+++ b/Sim_To_DuT_Interface/DuTLogger/DuTLogger.h
@@ -28,15 +28,13 @@ enum LOG_LEVEL_CHANGE_ON {
 static const quill::LogLevel DEFAULT_CONSOLE_LOG_LEVEL = quill::LogLevel::Info;
 static const quill::LogLevel DEFAULT_FILE_LOG_LEVEL = quill::LogLevel::Info;
 
-static bool enableConsoleToFile = true;
 static bool startedQuillEngine = false;
 
 
 class DuTLogger {
 
 public:
-    static void logMessage(std::string msg, LOG_LEVEL level);
-    static void disableConsoleToFileLogging(bool disable);
+    static void logMessage(std::string msg, LOG_LEVEL level, bool writeToFile);
     static void changeLogLevel(LOG_LEVEL_CHANGE_ON typ, LOG_LEVEL level);
 
 private:

--- a/Sim_To_DuT_Interface/DuTLogger/DuTLogger.h
+++ b/Sim_To_DuT_Interface/DuTLogger/DuTLogger.h
@@ -42,11 +42,17 @@ enum LOG_LEVEL_CHANGE_ON {
     CONSOLE_LOG, FILE_LOG
 };
 
-// pre-settings
-// feel free to change the default level for logging
+/**
+ * This constant stores the default level for console logging.
+ */
 static const quill::LogLevel DEFAULT_CONSOLE_LOG_LEVEL = quill::LogLevel::Info;
+
+/**
+ * This constant stores the default level for console file logging.
+ */
 static const quill::LogLevel DEFAULT_FILE_LOG_LEVEL = quill::LogLevel::Info;
 
+// Little variable to remember that the quill engine has been started.
 static bool startedQuillEngine = false;
 
 

--- a/Sim_To_DuT_Interface/DuTLogger/DuTLogger.h
+++ b/Sim_To_DuT_Interface/DuTLogger/DuTLogger.h
@@ -15,7 +15,7 @@ enum LOG_LEVEL{
     NONE, DEBUG, INFO, WARNING, ERROR, CRITICAL
 };
 
-enum LOGGER_TYP {
+enum LOGGER_TYPE {
     CONSOLE, DATA
 };
 
@@ -34,6 +34,7 @@ static bool startedQuillEngine = false;
 class DuTLogger {
 
 public:
+    static void logMessage(std::string msg, LOG_LEVEL level);
     static void logMessage(std::string msg, LOG_LEVEL level, bool writeToFile);
     static void changeLogLevel(LOG_LEVEL_CHANGE_ON typ, LOG_LEVEL level);
 
@@ -55,10 +56,10 @@ private:
     static void startEngine();
 
     // help functions
-    static std::string getLoggingPath(LOGGER_TYP typ);
+    static std::string getLoggingPath(LOGGER_TYPE type);
     static void createDirectoryIfNecessary(const std::string path);
     static void logWithLevel(quill::Logger* log, std::string msg, LOG_LEVEL level);
-    static quill::Handler* getHandlerTyp(LOG_LEVEL_CHANGE_ON typ);
+    static quill::Handler* getHandlerType(LOG_LEVEL_CHANGE_ON type);
 };
 
 

--- a/Sim_To_DuT_Interface/DuTLogger/DuTLogger.h
+++ b/Sim_To_DuT_Interface/DuTLogger/DuTLogger.h
@@ -1,0 +1,67 @@
+//
+// Created by marco on 26.10.21.
+//
+
+#ifndef TESTLOGGER_DUTLOGGER_H
+#define TESTLOGGER_DUTLOGGER_H
+#include <string>
+#include "quill/Quill.h"
+#include <filesystem>
+
+static const std::string PATH_CONSOLE_LOG = "/logs/console";
+static const std::string PATH_DATA_LOG = "/logs/data";
+
+enum LOG_LEVEL{
+    NONE, DEBUG, INFO, WARNING, ERROR, CRITICAL
+};
+
+enum LOGGER_TYP {
+    CONSOLE, DATA
+};
+
+enum LOG_LEVEL_CHANGE_ON {
+    CONSOLE_LOG, FILE_LOG
+};
+
+// pre-settings
+// feel free to change the default level for logging
+static const quill::LogLevel DEFAULT_CONSOLE_LOG_LEVEL = quill::LogLevel::Info;
+static const quill::LogLevel DEFAULT_FILE_LOG_LEVEL = quill::LogLevel::Info;
+
+static bool enableConsoleToFile = true;
+static bool startedQuillEngine = false;
+
+
+class DuTLogger {
+
+public:
+    static void logMessage(std::string msg, LOG_LEVEL level);
+    static void disableConsoleToFileLogging(bool disable);
+    static void changeLogLevel(LOG_LEVEL_CHANGE_ON typ, LOG_LEVEL level);
+
+private:
+    // define all required loggers
+    static quill::Logger* consoleLogger;
+    static quill::Logger* consoleFileLogger;
+    static quill::Logger* dataLogger;
+
+    // handlers (important to change the log_level
+    static quill::Handler* consoleHandler;
+    static quill::Handler* consoleFileHandler;
+    static quill::Handler* buildConsoleHandler();
+    static quill::Handler* buildFileHandler();
+
+    // functions to create and manage loggers
+    static quill::Logger* createConsoleLogger(const char* name, bool withFileHandler);
+    static quill::Logger* createDataLogger();
+    static void startEngine();
+
+    // help functions
+    static std::string getLoggingPath(LOGGER_TYP typ);
+    static void createDirectoryIfNecessary(const std::string path);
+    static void logWithLevel(quill::Logger* log, std::string msg, LOG_LEVEL level);
+    static quill::Handler* getHandlerTyp(LOG_LEVEL_CHANGE_ON typ);
+};
+
+
+#endif //TESTLOGGER_DUTLOGGER_H

--- a/Sim_To_DuT_Interface/DuTLogger/DuTLogger.h
+++ b/Sim_To_DuT_Interface/DuTLogger/DuTLogger.h
@@ -24,6 +24,9 @@ static const std::string FILE_MODE_CONSOLE = "w";
  */
 static const std::string FILE_MODE_DATA = "w";
 
+/**
+ * Defines the level of logging
+ */
 enum LOG_LEVEL{
     NONE, DEBUG, INFO, WARNING, ERROR, CRITICAL
 };
@@ -32,6 +35,9 @@ enum LOGGER_TYPE {
     CONSOLE, DATA
 };
 
+/**
+ * This enum collects all types of logger whose level can be changed
+ */
 enum LOG_LEVEL_CHANGE_ON {
     CONSOLE_LOG, FILE_LOG
 };

--- a/Sim_To_DuT_Interface/DuTLogger/DuTLogger.h
+++ b/Sim_To_DuT_Interface/DuTLogger/DuTLogger.h
@@ -11,6 +11,19 @@
 static const std::string PATH_CONSOLE_LOG = "/logs/console";
 static const std::string PATH_DATA_LOG = "/logs/data";
 
+/**
+ * This constant defines the mode how the logger will open the logfile of the console logging.
+ * Mode "w" creates a new file or overwrite the existing file at every start of the application.
+ * In mode "a" the logger tries to append it's content on an existing file.
+ */
+static const std::string FILE_MODE_CONSOLE = "w";
+/**
+ * This constant defines the mode how the logger will open the logfile of the data logging.
+ * Mode "w" creates a new file or overwrite the existing file at every start of the application.
+ * In mode "a" the logger tries to append it's content on an existing file.
+ */
+static const std::string FILE_MODE_DATA = "w";
+
 enum LOG_LEVEL{
     NONE, DEBUG, INFO, WARNING, ERROR, CRITICAL
 };

--- a/Sim_To_DuT_Interface/main.cpp
+++ b/Sim_To_DuT_Interface/main.cpp
@@ -5,10 +5,7 @@
 #include "DuTLogger/DuTLogger.h"
 
 int main() {
-
-    DuTLogger::logMessage("Test for Logging", LOG_LEVEL::INFO, false);
-    DuTLogger::logMessage("Test for Logging File", LOG_LEVEL::INFO, true);
-
+    
     Sim_To_DuT_Interface interface;
     // TODO Init Sim_Com_Handler
     // TODO Read Config and Create Connectors

--- a/Sim_To_DuT_Interface/main.cpp
+++ b/Sim_To_DuT_Interface/main.cpp
@@ -5,6 +5,8 @@
 #include "DuTLogger/DuTLogger.h"
 
 int main() {
+    DuTLogger::logMessage("Start Application", LOG_LEVEL::INFO);
+
     Sim_To_DuT_Interface interface;
     // TODO Init Sim_Com_Handler
     // TODO Read Config and Create Connectors

--- a/Sim_To_DuT_Interface/main.cpp
+++ b/Sim_To_DuT_Interface/main.cpp
@@ -6,7 +6,8 @@
 
 int main() {
 
-    DuTLogger::logMessage("Test for Logging", LOG_LEVEL::INFO);
+    DuTLogger::logMessage("Test for Logging", LOG_LEVEL::INFO, false);
+    DuTLogger::logMessage("Test for Logging File", LOG_LEVEL::INFO, true);
 
     Sim_To_DuT_Interface interface;
     // TODO Init Sim_Com_Handler

--- a/Sim_To_DuT_Interface/main.cpp
+++ b/Sim_To_DuT_Interface/main.cpp
@@ -5,7 +5,6 @@
 #include "DuTLogger/DuTLogger.h"
 
 int main() {
-    
     Sim_To_DuT_Interface interface;
     // TODO Init Sim_Com_Handler
     // TODO Read Config and Create Connectors

--- a/Sim_To_DuT_Interface/main.cpp
+++ b/Sim_To_DuT_Interface/main.cpp
@@ -2,8 +2,12 @@
 #include "Sim_To_DuT_Interface.h"
 #include "DuT_Connectors/DuT_Connector.h"
 #include "DuT_Connectors/DuT_Info.h"
+#include "DuTLogger/DuTLogger.h"
 
 int main() {
+
+    DuTLogger::logMessage("Test for Logging", LOG_LEVEL::INFO);
+
     Sim_To_DuT_Interface interface;
     // TODO Init Sim_Com_Handler
     // TODO Read Config and Create Connectors


### PR DESCRIPTION
Adds the DuT_Logger to log messages. 
All methods for logging are static , so nobody has to create an instance of the logger.
Creates and manages logfiles. 
Can't log Events so far, because we don't know the implementation of the event object yet.