### PR TITLE
Logger config

### DIFF
--- a/Sim_To_DuT_Interface/DuTLogger/DuTLogger.cpp
+++ b/Sim_To_DuT_Interface/DuTLogger/DuTLogger.cpp
@@ -247,7 +247,7 @@ void DuTLogger::changeLogLevel(LOG_TYPE type, LOG_LEVEL level) {
     if (!initialized) {
         std::cerr << "Logger has not been initialized. Please parse a config to the logger." << std::endl;
     }
-
+    // get the right handler. We want to make changes on this one.
     quill::Handler* handler = DuTLogger::getHandlerType(type);
 
     // log all messages before changing the level

--- a/Sim_To_DuT_Interface/DuTLogger/DuTLogger.cpp
+++ b/Sim_To_DuT_Interface/DuTLogger/DuTLogger.cpp
@@ -45,6 +45,9 @@ void DuTLogger::initializeLogger(const LoggerConfig con) {
     // initialize the CSV file for data logging
     LOG_INFO(dataLogger, "{}", CSV_HEADER);
 
+    // remember that we've initialized the logger
+    initialized = true;
+
     // check if the user want to use another logging level than the default one
     if (con.fileLogLevel != LOG_LEVEL::INFO) {
         changeLogLevel(LOG_TYPE::FILE_LOG, con.fileLogLevel);
@@ -52,9 +55,6 @@ void DuTLogger::initializeLogger(const LoggerConfig con) {
     if (con.consoleLogLevel != LOG_LEVEL::INFO) {
         changeLogLevel(LOG_TYPE::CONSOLE_LOG, con.consoleLogLevel);
     }
-
-    // remember that we've initialized the logger
-    initialized = true;
 }
 
 /**

--- a/Sim_To_DuT_Interface/DuTLogger/DuTLogger.h
+++ b/Sim_To_DuT_Interface/DuTLogger/DuTLogger.h
@@ -35,18 +35,10 @@ static const std::string FILE_MODE_CONSOLE = "w";
 static const std::string FILE_MODE_DATA = "w";
 
 /**
- * Defines the level of logging
+ * This constant contains the header of the csv files. This header will be printed in the first line of the files and
+ * represents the order and meaning of the logged values.
  */
-enum LOG_LEVEL{
-    NONE, DEBUG, INFO, WARNING, ERROR, CRITICAL
-};
-
-/**
- * Defines the type and so the task for the logger.
- */
-enum LOGGER_TYPE {
-    CONSOLE, DATA
-};
+static const std::string CSV_HEADER = "Operation,Value,Origin,Timestamp";
 
 /**
  * This enum collects all types of logger whose level can be changed.
@@ -54,15 +46,9 @@ enum LOGGER_TYPE {
  * Please notice that you can't change the level of the data logging, because all data objects will be logged with
  * the same level.
  */
-enum LOG_LEVEL_CHANGE_ON {
+enum LOG_TYPE {
     CONSOLE_LOG, FILE_LOG
 };
-
-// Little variable to remember that the quill engine has been started.
-static bool startedQuillEngine = false;
-
-// Boolean to check if the header has been printed to the data file yet.
-static bool csvHeaderPrinted = false;
 
 /**
  * This logger is a tool with specialized functions to log and store messages for all elements of the
@@ -84,10 +70,11 @@ public:
     static void initializeLogger(LoggerConfig con);
     static void logMessage(std::string msg, LOG_LEVEL level);
     static void logMessage(std::string msg, LOG_LEVEL level, bool writeToFile);
-    static void changeLogLevel(LOG_LEVEL_CHANGE_ON typ, LOG_LEVEL level);
+    static void changeLogLevel(LOG_TYPE typ, LOG_LEVEL level);
     static void logEvent(sim_interface::SimEvent event);
 
 private:
+    // variable to remember if the logger has been initialized yet
     static bool initialized;
 
     // define all required loggers
@@ -98,17 +85,16 @@ private:
     // handlers (important to change the log_level
     static quill::Handler* consoleHandler;
     static quill::Handler* consoleFileHandler;
-    static quill::Handler* buildConsoleHandler(bool enableDebugMode, quill::LogLevel defaultConsoleLogLevel);
-    static quill::Handler* buildFileHandler(std::string logPath, bool enableDebugMode, quill::LogLevel defaultFileLogLevel);
+    static quill::Handler* buildConsoleHandler(bool enableDebugMode);
+    static quill::Handler* buildFileHandler(std::string logPath, bool enableDebugMode);
 
     // functions to create and manage loggers
     static quill::Logger* createConsoleLogger(const char* name, bool withFileHandler);
     static quill::Logger* createDataLogger(std::string logPath);
-    static void startEngine();
 
     // help functions
     static void logWithLevel(quill::Logger* log, std::string msg, LOG_LEVEL level);
-    static quill::Handler* getHandlerType(LOG_LEVEL_CHANGE_ON type);
+    static quill::Handler* getHandlerType(LOG_TYPE type);
     static std::string getCurrentTimestamp();
 
     // file management

--- a/Sim_To_DuT_Interface/DuTLogger/DuTLogger.h
+++ b/Sim_To_DuT_Interface/DuTLogger/DuTLogger.h
@@ -81,28 +81,29 @@ static bool csvHeaderPrinted = false;
 class DuTLogger {
 
 public:
+    static void initializeLogger(LoggerConfig con);
     static void logMessage(std::string msg, LOG_LEVEL level);
     static void logMessage(std::string msg, LOG_LEVEL level, bool writeToFile);
     static void changeLogLevel(LOG_LEVEL_CHANGE_ON typ, LOG_LEVEL level);
     static void logEvent(sim_interface::SimEvent event);
 
 private:
+    static bool initialized;
+
     // define all required loggers
     static quill::Logger* consoleLogger;
     static quill::Logger* consoleFileLogger;
     static quill::Logger* dataLogger;
-    static std::string currentLogpathConsole;
-    static std::string currentLogpathData;
 
     // handlers (important to change the log_level
     static quill::Handler* consoleHandler;
     static quill::Handler* consoleFileHandler;
-    static quill::Handler* buildConsoleHandler();
-    static quill::Handler* buildFileHandler();
+    static quill::Handler* buildConsoleHandler(bool enableDebugMode, quill::LogLevel defaultConsoleLogLevel);
+    static quill::Handler* buildFileHandler(std::string logPath, bool enableDebugMode, quill::LogLevel defaultFileLogLevel);
 
     // functions to create and manage loggers
     static quill::Logger* createConsoleLogger(const char* name, bool withFileHandler);
-    static quill::Logger* createDataLogger();
+    static quill::Logger* createDataLogger(std::string logPath);
     static void startEngine();
 
     // help functions
@@ -111,9 +112,9 @@ private:
     static std::string getCurrentTimestamp();
 
     // file management
-    static std::string getLoggingPath(LOGGER_TYPE type);
-    static std::string initializeLoggingPath(LOGGER_TYPE type);
-    static void removeOldLogfiles(std::string directory);
+    static std::string getLoggingPath(std::string logPath);
+    static std::string initializeLoggingPath(std::string logPath);
+    static void removeOldLogfiles(std::string directory, int backupCount);
 };
 
 #endif //SIM_TO_DUT_INTERFACE_DUTLOGGER_H

--- a/Sim_To_DuT_Interface/DuTLogger/DuTLoggerConfig.h
+++ b/Sim_To_DuT_Interface/DuTLogger/DuTLoggerConfig.h
@@ -10,6 +10,7 @@
 #define SIM_TO_DUT_INTERFACE_DUTLOGGERCONFIG_H
 
 #include <string>
+#include <cassert>
 
 /**
  * Defines the level of logging
@@ -50,6 +51,9 @@ public:
                  : enableDebugMode(std::move(enableDebugMode)), pathConsoleLog(std::move(pathConsoleLog)),
                  pathDataLog(std::move(pathDataLog)), fileBackupCount(std::move(fileBackupCount)),
                  fileLogLevel(std::move(fileLogLevel)), consoleLogLevel(std::move(consoleLogLevel)) {
+        assert (this->fileBackupCount > 0);
+        assert (!this->pathConsoleLog.empty());
+        assert (!this->pathDataLog.empty());
     }
 
     bool enableDebugMode = false;

--- a/Sim_To_DuT_Interface/DuTLogger/DuTLoggerConfig.h
+++ b/Sim_To_DuT_Interface/DuTLogger/DuTLoggerConfig.h
@@ -10,79 +10,53 @@
 #define SIM_TO_DUT_INTERFACE_DUTLOGGERCONFIG_H
 
 #include <string>
-#include "quill/Quill.h"
 
 /**
- * If this constant is true, the debug mode for logging is activated. In debug mode the console will show all
- * debug messages and write all of them in the logfile. The default logging level will be ignored.
+ * Defines the level of logging
  */
-static const bool ENABLE_DEBUG_MODE = false;
+enum LOG_LEVEL{
+    NONE, DEBUG, INFO, WARNING, ERROR, CRITICAL
+};
 
 /**
- * Defines the path where the console messages will be logged.
- * It is possible to use a relative path. In this case the configured below will be appended on the path of
- * application's execution. An example for a relative path is "/logs/console".
- * Please notice that there is no '/' at the end.
- * If you rather want to define an absolute path please add an additional '#' in front of your absolute path.
- * An example for an absolute path is "#/home/user/project/logs/console"
+ * The logger needs a configuration before it can start logging. This configuration has to store all required
+ * information that the logger needs. Default settings are provided.
  */
-static const std::string PATH_CONSOLE_LOG = "/logs/console";
-
-/**
- * Defines the path where the data objects will be logged.
- * It is possible to use a relative path. In this case the configured below will be appended on the path of
- * application's execution. An example for a relative path is "/logs/data".
- * Please notice that there is no '/' at the end.
- * If you rather want to define an absolute path please add an additional '#' in front of your absolute path.
- * An example for an absolute path is "#/home/user/project/logs/data"
- */
-static const std::string PATH_DATA_LOG = "/logs/data";
-
-/**
- * This constant defines the maximum number of files in a logging directory. If there are more
- * logfiles under the underlying path, old ones will be deleted. (like a date based file rotation)
- */
-static const int FILE_BACKUP_COUNT = 10;
-
-/**
- * This constant stores the default level for console logging.
- * Please define here the start logging level you would like to log with.
- * If the debug mode is on, this level will be ignored!
- *
- * During the execution the level can be manually changed by the function below.
- *
- * @see void changeLogLevel(LOG_LEVEL_CHANGE_ON typ, LOG_LEVEL level)
- */
-static const quill::LogLevel DEFAULT_CONSOLE_LOG_LEVEL = quill::LogLevel::Info;
-
-/**
- * This constant stores the default level for console file logging.
- * Please define here the start logging level you would like to log with.
- * If the debug mode is on, this level will be ignored!
- *
- * During the execution the level can be manually changed by the function below.
- *
- * @see void changeLogLevel(LOG_LEVEL_CHANGE_ON typ, LOG_LEVEL level)
- */
-static const quill::LogLevel DEFAULT_FILE_LOG_LEVEL = quill::LogLevel::Info;
-
 class LoggerConfig {
 public:
-    LoggerConfig(bool enableDebugMode, std::string pathConsoleLog, std::string pathDataLog,
-                 int fileBackupCount, quill::LogLevel defaultConsoleLogLevel, quill::LogLevel defaultFileLogLevel)
+
+    /**
+     * Creates the essential configuration for the logger with default settings.
+     */
+    LoggerConfig() {}
+
+    /**
+     * Create the essential configuration for the logger.
+     * <br>
+     * For the logging paths it's possible to enter relative and absolute file paths. Both variants will be accepted.
+     * An example for a relative path is "/logs/console". Please notice that there is no '/' at the end.
+     * If you rather want to define an absolute path please add an additional '#' in front of your absolute path.
+     * An example for an absolute path is "#/home/user/project/logs/console"
+     *
+     * @param enableDebugMode   - enables debug mode for logging. Logging levels will be ignored.
+     * @param pathConsoleLog    - contains the path to write the console log into a file
+     * @param pathDataLog       - contains the path to write the data log into a file
+     * @param fileBackupCount   - defines maximum amount of files in a logging directory. Old files will be deleted.
+     * @param fileLogLevel      - defines the logging level for the file log
+     * @param consoleLogLevel   - defines the logging level for the console log
+     */
+    LoggerConfig(bool enableDebugMode, std::string pathConsoleLog, std::string pathDataLog, int fileBackupCount)
                  : enableDebugMode(std::move(enableDebugMode)), pathConsoleLog(std::move(pathConsoleLog)),
                  pathDataLog(std::move(pathDataLog)), fileBackupCount(std::move(fileBackupCount)),
-                 defaultConsoleLogLevel(std::move(defaultConsoleLogLevel)),
-                 defaultFileLogLevel(std::move(defaultFileLogLevel)) {
-
+                 fileLogLevel(std::move(fileLogLevel)), consoleLogLevel(std::move(consoleLogLevel)) {
     }
 
     bool enableDebugMode = false;
     std::string pathConsoleLog = "/logs/console";
     std::string pathDataLog = "/logs/data";
     int fileBackupCount = 10;
-    quill::LogLevel defaultConsoleLogLevel = quill::LogLevel::Info;
-    quill::LogLevel defaultFileLogLevel = quill::LogLevel::Info;
+    LOG_LEVEL fileLogLevel = LOG_LEVEL::INFO;
+    LOG_LEVEL consoleLogLevel = LOG_LEVEL::INFO;
 };
 
 

--- a/Sim_To_DuT_Interface/DuTLogger/DuTLoggerConfig.h
+++ b/Sim_To_DuT_Interface/DuTLogger/DuTLoggerConfig.h
@@ -45,7 +45,8 @@ public:
      * @param fileLogLevel      - defines the logging level for the file log
      * @param consoleLogLevel   - defines the logging level for the console log
      */
-    LoggerConfig(bool enableDebugMode, std::string pathConsoleLog, std::string pathDataLog, int fileBackupCount)
+    LoggerConfig(bool enableDebugMode, std::string pathConsoleLog, std::string pathDataLog, int fileBackupCount,
+                 LOG_LEVEL fileLogLevel, LOG_LEVEL consoleLogLevel)
                  : enableDebugMode(std::move(enableDebugMode)), pathConsoleLog(std::move(pathConsoleLog)),
                  pathDataLog(std::move(pathDataLog)), fileBackupCount(std::move(fileBackupCount)),
                  fileLogLevel(std::move(fileLogLevel)), consoleLogLevel(std::move(consoleLogLevel)) {

--- a/Sim_To_DuT_Interface/DuTLogger/DuTLoggerConfig.h
+++ b/Sim_To_DuT_Interface/DuTLogger/DuTLoggerConfig.h
@@ -66,4 +66,24 @@ static const quill::LogLevel DEFAULT_CONSOLE_LOG_LEVEL = quill::LogLevel::Info;
  */
 static const quill::LogLevel DEFAULT_FILE_LOG_LEVEL = quill::LogLevel::Info;
 
+class LoggerConfig {
+public:
+    LoggerConfig(bool enableDebugMode, std::string pathConsoleLog, std::string pathDataLog,
+                 int fileBackupCount, quill::LogLevel defaultConsoleLogLevel, quill::LogLevel defaultFileLogLevel)
+                 : enableDebugMode(std::move(enableDebugMode)), pathConsoleLog(std::move(pathConsoleLog)),
+                 pathDataLog(std::move(pathDataLog)), fileBackupCount(std::move(fileBackupCount)),
+                 defaultConsoleLogLevel(std::move(defaultConsoleLogLevel)),
+                 defaultFileLogLevel(std::move(defaultFileLogLevel)) {
+
+    }
+
+    bool enableDebugMode = false;
+    std::string pathConsoleLog = "/logs/console";
+    std::string pathDataLog = "/logs/data";
+    int fileBackupCount = 10;
+    quill::LogLevel defaultConsoleLogLevel = quill::LogLevel::Info;
+    quill::LogLevel defaultFileLogLevel = quill::LogLevel::Info;
+};
+
+
 #endif //SIM_TO_DUT_INTERFACE_DUTLOGGERCONFIG_H

--- a/Sim_To_DuT_Interface/main.cpp
+++ b/Sim_To_DuT_Interface/main.cpp
@@ -33,8 +33,12 @@
 #include "DuT_Connectors/CANConnector/CANConnectorConfig.h"
 #include "Sim_Communication/SimComHandler.h"
 #include "DuTLogger/DuTLogger.h"
+#include "DuTLoggerConfig.h"
 
 int main() {
+    DuTLogger::initializeLogger(LoggerConfig(false, "/logs/console",
+                                             "/logs/data", 10, quill::LogLevel::Info,
+                                             quill::LogLevel::Info));
     DuTLogger::logMessage("Start Application", LOG_LEVEL::INFO);
 
     // Create interface

--- a/Sim_To_DuT_Interface/main.cpp
+++ b/Sim_To_DuT_Interface/main.cpp
@@ -33,12 +33,11 @@
 #include "DuT_Connectors/CANConnector/CANConnectorConfig.h"
 #include "Sim_Communication/SimComHandler.h"
 #include "DuTLogger/DuTLogger.h"
-#include "DuTLoggerConfig.h"
 
 int main() {
     // initialize the logger
     DuTLogger::initializeLogger(LoggerConfig());
-    
+
     DuTLogger::logMessage("Start Application", LOG_LEVEL::INFO);
 
     // Create interface

--- a/Sim_To_DuT_Interface/main.cpp
+++ b/Sim_To_DuT_Interface/main.cpp
@@ -36,9 +36,9 @@
 #include "DuTLoggerConfig.h"
 
 int main() {
-    DuTLogger::initializeLogger(LoggerConfig(false, "/logs/console",
-                                             "/logs/data", 10, quill::LogLevel::Info,
-                                             quill::LogLevel::Info));
+    // initialize the logger
+    DuTLogger::initializeLogger(LoggerConfig());
+    
     DuTLogger::logMessage("Start Application", LOG_LEVEL::INFO);
 
     // Create interface


### PR DESCRIPTION
Konstanten entfernt und stattdessen eine Config Klasse eingebunden. Diese kann vom Logger auch erkannt und übernommen werden. Hierzu gibt es eine Funktion "initializeLogger", der man die Konfiguration mitgeben kann. 
Weiterhin wurden unschöne bools und unnötige enums entfernt

Änderungen hauptsächlich: Konstanten durch Variablen der Konfiguration ersetzt.

Hinzufügen von Namespaces und Rüberziehen von Doc in header folgt in nächstem PR (da manche noch am logging arbeiten)