### PR TITLE
Can Connector logging

### DIFF
--- a/Sim_To_DuT_Interface/DuT_Connectors/CANConnector/CANConnector.cpp
+++ b/Sim_To_DuT_Interface/DuT_Connectors/CANConnector/CANConnector.cpp
@@ -12,7 +12,10 @@
 /*******************************************************************************
  * INCLUDES
  ******************************************************************************/
+// Project includes
 #include "CANConnector.h"
+
+// System includes
 
 
 /*******************************************************************************
@@ -20,12 +23,6 @@
  ******************************************************************************/
 namespace sim_interface::dut_connector::can{
 
-    /**
-     * CAN Connector constructor.
-     *
-     * @param queueDuTToSim - Queue to write received simulation events to.
-     * @param config        - Configuration for the connector.
-     */
     CANConnector::CANConnector(
             std::shared_ptr<SharedQueue<SimEvent>> queueDuTToSim,
             const CANConnectorConfig &config):
@@ -64,9 +61,6 @@ namespace sim_interface::dut_connector::can{
         std::cout << "CAN Connector created" << std::endl;
     }
 
-    /**
-    * CAN Connector destructor.
-    */
     CANConnector::~CANConnector(){
 
         // Stop the io context loop
@@ -75,11 +69,6 @@ namespace sim_interface::dut_connector::can{
         std::cout << "CAN Connector destroyed" << std::endl;
     }
 
-    /**
-    * Creates the bcmSocket data member.
-    *
-    * @return The BCM socket.
-    */
     boost::asio::generic::datagram_protocol::socket CANConnector::createBcmSocket(const CANConnectorConfig &config){
 
         // Error code return value
@@ -119,9 +108,6 @@ namespace sim_interface::dut_connector::can{
         return socket;
     }
 
-    /**
-    * Stats the io context loop.
-    */
     void CANConnector::startProcessing(){
 
         // Run the io context in its own thread
@@ -130,9 +116,6 @@ namespace sim_interface::dut_connector::can{
         std::cout << "CAN Connector starting io context loop processing" << std::endl;
     }
 
-    /**
-    * Stops the io context loop.
-    */
     void CANConnector::stopProcessing(){
 
         // Check if we need to stop the io context loop
@@ -150,31 +133,20 @@ namespace sim_interface::dut_connector::can{
         std::cout << "CAN Connector stopped io context loop processing" << std::endl;
     }
 
-    /**
-    * Thread for the io context loop.
-    */
     void CANConnector::ioContextThreadFunction(const boost::shared_ptr<boost::asio::io_context>& context){
         context->run();
     }
 
-    /**
-     * Gets information about the CAN Connector
-     *
-     * @return info - The connector information
-     */
     ConnectorInfo CANConnector::getConnectorInfo(){
+
         ConnectorInfo info(
                 "CAN Connector",
                 0x0000001,
                 "The CAN Connector enables the communication over a CAN/CANFD interface.");
+
         return info;
     }
 
-    /**
-    * Receives on the BCM socket. The received data is stored in the rxBuffer.
-    * After processing the receive operation the next receive operation is
-    * created to keep  the io context loop running.
-    */
     void CANConnector::receiveOnSocket(){
 
         std::cout << "CAN Connector created new receive operation" << std::endl;
@@ -237,12 +209,6 @@ namespace sim_interface::dut_connector::can{
 
     }
 
-    /**
-    * Create a non cyclic transmission task for a single CAN/CANFD frame.
-    *
-    * @param frame   - The frame that should be send.
-    * @param isCANFD - Flag for a CANFD frame.
-    */
     void CANConnector::txSendSingleFrame(struct canfd_frame frame, bool isCANFD){
 
         // BCM message we are sending with a single CAN or CANFD frame
@@ -307,13 +273,6 @@ namespace sim_interface::dut_connector::can{
 
     }
 
-    /**
-    * Create a non cyclic transmission task for multiple CAN/CANFD frames.
-    *
-    * @param frames  - The frames that should be send.
-    * @param nframes - The number of frames that should be send.
-    * @param isCANFD - Flag for CANFD frames.
-    */
     void CANConnector::txSendMultipleFrames(struct canfd_frame frames[], int nframes, bool isCANFD){
 
         // Note: The TX_SEND operation can only handle exactly one frame!
@@ -324,16 +283,6 @@ namespace sim_interface::dut_connector::can{
 
     }
 
-    /**
-    * Create a cyclic transmission task for a CAN/CANFD frame.
-    *
-    * @param frame   - The frame that should be send cyclic.
-    * @param count   - Number of times the frame is send with the first interval.
-    *                  If count is zero only the second interval is being used.
-    * @param ival1   - First interval.
-    * @param ival2   - Second interval.
-    * @param isCANFD - Flag for a CANFD frames.
-    */
     void CANConnector::txSetupSingleFrame(struct canfd_frame frame, uint32_t count, struct bcm_timeval ival1,
                                           struct bcm_timeval ival2, bool isCANFD){
 
@@ -405,23 +354,6 @@ namespace sim_interface::dut_connector::can{
 
     }
 
-    /**
-     * Create a cyclic transmission task for multiple CAN/CANFD frames.
-    *
-    * Note: The frames will not be send as a atomic sequence. We send for each TX_SETUP
-    * a single CAN/CANFD frame with its CAN ID in the bcm_msg_head. This way we do not
-    * create a cyclic transmission sequence which can only be removed with the CAN ID
-    * that was set in the bcm_msg_head. Another benefit is that each CAN/CANFD frame
-    * can have different count, ival1, and ival2 values.
-    *
-    * @param frames  - The frames that should be send cyclic.
-    * @param nframes - The number of frames that should be send cyclic.
-    * @param count   - Number of times the frame is send with the first interval.
-    *                  If count is zero only the second interval is being used.
-    * @param ival1   - First interval.
-    * @param ival2   - Second interval.
-    *  @param isCANFD - Flag for CANFD frames.
-    */
     void CANConnector::txSetupMultipleFrames(struct canfd_frame frames[], int nframes, uint32_t count[], struct bcm_timeval ival1[],
                                              struct bcm_timeval ival2[], bool isCANFD){
 
@@ -431,22 +363,6 @@ namespace sim_interface::dut_connector::can{
 
     }
 
-    /**
-    * Create a cyclic transmission task for one or multiple CAN/CANFD frames.
-    * If more than one frame should be send cyclic the provided sequence of
-    * the frames is kept by the BCM.
-    *
-    * Note: The cyclic transmission task for the sequence can only be deleted
-    * with the CAN ID that was set in the bcm_msg_head.
-    *
-    * @param frames   - The array of CAN/CANFD frames that should be send cyclic.
-    * @param nframes  - The number of CAN/CANFD frames that should be send cyclic.
-    * @param count    - Number of times the frame is send with the first interval.
-    *                   If count is zero only the second interval is being used.
-    * @param ival1    - First interval.
-    * @param ival2    - Second interval.
-    * @param isCANFD  - Flag for CANFD frames.
-    */
     void CANConnector::txSetupSequence(struct canfd_frame frames[], int nframes, uint32_t count,
                                        struct bcm_timeval ival1, struct bcm_timeval ival2, bool isCANFD){
 
@@ -524,14 +440,6 @@ namespace sim_interface::dut_connector::can{
 
     }
 
-    /**
-    * Updates a cyclic transmission task for a CAN/CANFD frame.
-    *
-    * @param frames   - The updated CAN/CANFD frame data.
-    * @param nframes  - The number of CAN/CANFD frames that should be updated.
-    * @param isCANFD  - Flag for CANFD frames.
-    * @param announce - Flag for immediately sending out the changes once will retaining the cycle.
-    */
     void CANConnector::txSetupUpdateSingleFrame(struct canfd_frame frame, bool isCANFD, bool announce){
 
         // BCM message we are sending with a single CAN or CANFD frame
@@ -605,14 +513,6 @@ namespace sim_interface::dut_connector::can{
 
     }
 
-    /**
-    * Updates a cyclic transmission task for one or multiple CAN/CANFD frames.
-    *
-    * @param frames   - The array of CAN/CANFD frames with the updated data.
-    * @param nframes  - The number of CAN/CANFD frames that should be updated.
-    * @param isCANFD  - Flag for CANFD frames.
-    * @param announce - Flag for immediately sending out the changes once while retaining the cycle.
-    */
     void CANConnector::txSetupUpdateMultipleFrames(struct canfd_frame frames[], int nframes, bool isCANFD, bool announce){
 
         for(int index = 0; index < nframes; index++){
@@ -621,14 +521,6 @@ namespace sim_interface::dut_connector::can{
 
     }
 
-    /**
-    * Removes a cyclic transmission task for the given CAN ID.
-    *
-    * Note: A cyclic transmission task for a sequence of frames can only
-    * be deleted with the CAN ID that was set in the bcm_msg_head.
-    *
-    * @param canID - The CAN ID of the task that should be removed.
-    */
     void CANConnector::txDelete(canid_t canID, bool isCANFD){
 
         // BCM message we are sending
@@ -660,13 +552,6 @@ namespace sim_interface::dut_connector::can{
 
     }
 
-    /**
-     * Creates a RX filter for the given CAN ID.
-    * I. e. we get notified on all received frames with this CAN ID.
-    *
-    * @param canID    - The CAN ID that should be added to the RX filter.
-    * @param isCANFD  - Flag for CANFD frames.
-    */
     void CANConnector::rxSetupCanID(canid_t canID, bool isCANFD){
 
         // BCM message we are sending
@@ -699,14 +584,6 @@ namespace sim_interface::dut_connector::can{
 
     }
 
-    /**
-    * Creates a RX filter for the CAN ID and the relevant bits of the frame.
-    * I. e. we only get notified on changes for the set bits in the mask.
-    *
-    * @param canID    - The CAN ID that should be added to the RX filter.
-    * @param mask     - The mask for the relevant bits of the frame.
-    * @param isCANFD  - Flag for CANFD frames.
-    */
     void CANConnector::rxSetupMask(canid_t canID, struct canfd_frame mask, bool isCANFD){
 
         // BCM message we are sending with a single CAN or CANFD frame
@@ -768,12 +645,6 @@ namespace sim_interface::dut_connector::can{
         });
     }
 
-    /**
-    * Removes the RX filter for the given CAN ID.
-    *
-    * @param canID   - The CAN ID that should be removed from the RX filter.
-    * @param isCANFD - Flag for CANFD frames.
-    */
     void CANConnector::rxDelete(canid_t canID, bool isCANFD){
 
         // BCM message we are sending
@@ -805,14 +676,6 @@ namespace sim_interface::dut_connector::can{
 
     }
 
-    /**
-    * Decides what to do with the data we received on the socket.
-    *
-    * @param head    - The received bcm msg head.
-    * @param frames  - The received CAN or CANFD frames.
-    * @param nframes - The number of the received frames.
-    * @param isCANFD - Flag for CANFD frames.
-    */
     void CANConnector::handleReceivedData(const bcm_msg_head *head, void *frames, uint32_t nframes, bool isCANFD){
 
         std::cout << "Handling the received data" << std::endl;
@@ -828,7 +691,8 @@ namespace sim_interface::dut_connector::can{
 
             case RX_TIMEOUT:
 
-                // Cyclic message is detected to be absent.
+                // Cyclic message is detected to be absent by the timeout monitoring.
+                // There is no function implemented yet that should cause/use this.
                 std::cout << "RX_TIMEOUT is not implemented" << std::endl;
                 break;
 
@@ -860,11 +724,6 @@ namespace sim_interface::dut_connector::can{
 
     }
 
-    /**
-    * Decides what to do with the event we received from the simulation.
-    *
-    * @param event - The event we received from the simulation.
-    */
     void CANConnector::handleEventSingle(const SimEvent &event){
 
         // Test CAN Frame

--- a/Sim_To_DuT_Interface/DuT_Connectors/CANConnector/CANConnector.h
+++ b/Sim_To_DuT_Interface/DuT_Connectors/CANConnector/CANConnector.h
@@ -87,43 +87,210 @@ namespace sim_interface::dut_connector::can{
 
     public:
         // Functions members
+
+        /**
+        * CAN Connector constructor.
+        * Configures the BCM socket based on the provided receive configuration.
+        * Starts the io_context- and receive-loop of the CAN Connector.
+        *
+        * @param queueDuTToSim - Queue to write received simulation events to.
+        * @param config        - Configuration for the connector.
+        */
         CANConnector(std::shared_ptr<SharedQueue<SimEvent>> queueDuTToSim, const CANConnectorConfig &config);
+
+        /**
+        * CAN Connector destructor.
+        * Stops the io_context loop of the CAN Connector.
+        */
         ~CANConnector();
 
+        /**
+        * Gets information about the CAN Connector
+        *
+        * @return info - The connector information
+        */
         ConnectorInfo getConnectorInfo() override;
+
+        /**
+        * Decides what to do with the event we received from the simulation.
+        *
+        * @param event - The event we received from the simulation.
+        */
         void handleEventSingle(const SimEvent &event) override;
 
         // Data members
 
     private:
         // Function members
+
+        /**
+        * Creates the BCM socket that is used by the CAN Connector.
+        *
+        * @return The BCM socket.
+        */
         boost::asio::generic::datagram_protocol::socket createBcmSocket(const CANConnectorConfig &config);
 
+        /**
+        * Starts the io context loop that is running in a dedicated thread.
+        * Note: Because io_context.run() is a blocking call it needs the dedicated thread.
+        */
         void startProcessing();
+
+        /**
+        * Stops the io context loop.
+        */
         void stopProcessing();
+
+        /**
+        * Thread function for the io context loop.
+        */
         void ioContextThreadFunction(const boost::shared_ptr<boost::asio::io_context>& context);
 
+        /**
+        * Receives on the BCM socket. The received data is stored in the rxBuffer.
+        * After processing the receive operation the next receive operation is
+        * created (function calls itself) to keep the io context loop running.
+        */
         void receiveOnSocket();
+
+        /**
+        * Decides what to do with the data we received on the socket.
+        *
+        * @param head    - The received bcm msg head.
+        * @param frames  - The received CAN or CANFD frames.
+        * @param nframes - The number of the received frames.
+        * @param isCANFD - Flag for CANFD frames.
+        */
         void handleReceivedData(const bcm_msg_head* head, void* frames, uint32_t nframes, bool isCANFD);
 
+        /**
+        * Create a non cyclic transmission task for a single CAN/CANFD frame.
+        *
+        * @param frame   - The frame that should be send.
+        * @param isCANFD - Flag for a CANFD frame.
+        */
         void txSendSingleFrame(struct canfd_frame frame, bool isCANFD);
+
+        /**
+        * Create a non cyclic transmission task for multiple CAN/CANFD frames.
+        *
+        * @param frames  - The frames that should be send.
+        * @param nframes - The number of frames that should be send.
+        * @param isCANFD - Flag for CANFD frames.
+        */
         void txSendMultipleFrames(struct canfd_frame frames[], int nframes, bool isCANFD);
+
+        /**
+        * Create a cyclic transmission task for a CAN/CANFD frame.
+        *
+        * @param frame   - The frame that should be send cyclic.
+        * @param count   - Number of times the frame is send with the first interval.
+        *                  If count is zero only the second interval is being used.
+        * @param ival1   - First interval.
+        * @param ival2   - Second interval.
+        * @param isCANFD - Flag for a CANFD frames.
+        */
         void txSetupSingleFrame(struct canfd_frame frame, uint32_t count, struct bcm_timeval ival1, struct bcm_timeval ival2, bool isCANFD);
+
+        /**
+        * Create a cyclic transmission task for multiple CAN/CANFD frames.
+        *
+        * Note: The frames will not be send as a atomic sequence. We send for each TX_SETUP
+        * a single CAN/CANFD frame with its CAN ID in the bcm_msg_head. This way we do not
+        * create a cyclic transmission sequence which can only be removed with the CAN ID
+        * that was set in the bcm_msg_head. Another benefit is that each CAN/CANFD frame
+        * can have different count, ival1, and ival2 values.
+        *
+        * @param frames  - The frames that should be send cyclic.
+        * @param nframes - The number of frames that should be send cyclic.
+        * @param count   - Number of times the frame is send with the first interval.
+        *                  If count is zero only the second interval is being used.
+        * @param ival1   - First interval.
+        * @param ival2   - Second interval.
+        * @param isCANFD - Flag for CANFD frames.
+        */
         void txSetupMultipleFrames(struct canfd_frame frames[], int nframes, uint32_t count[], struct bcm_timeval ival1[], struct bcm_timeval ival2[], bool isCANFD);
+
+        /**
+        * Create a cyclic transmission task for one or multiple CAN/CANFD frames.
+        * If more than one frame should be send cyclic the provided sequence of
+        * the frames is kept by the BCM.
+        *
+        * Note: The cyclic transmission task for the sequence can only be deleted
+        * with the CAN ID that was set in the bcm_msg_head.
+        *
+        * @param frames   - The array of CAN/CANFD frames that should be send cyclic.
+        * @param nframes  - The number of CAN/CANFD frames that should be send cyclic.
+        * @param count    - Number of times the frame is send with the first interval.
+        *                   If count is zero only the second interval is being used.
+        * @param ival1    - First interval.
+        * @param ival2    - Second interval.
+        * @param isCANFD  - Flag for CANFD frames.
+        */
         void txSetupSequence(struct canfd_frame frames[], int nframes, uint32_t count, struct bcm_timeval ival1, struct bcm_timeval ival2, bool isCANFD);
+
+        /**
+        * Updates a cyclic transmission task for a CAN/CANFD frame.
+        *
+        * @param frames   - The updated CAN/CANFD frame data.
+        * @param nframes  - The number of CAN/CANFD frames that should be updated.
+        * @param isCANFD  - Flag for CANFD frames.
+        * @param announce - Flag for immediately sending out the changes once will retaining the cycle.
+        */
         void txSetupUpdateSingleFrame(struct canfd_frame frame, bool isCANFD, bool announce);
+
+        /**
+        * Updates a cyclic transmission task for one or multiple CAN/CANFD frames.
+        *
+        * @param frames   - The array of CAN/CANFD frames with the updated data.
+        * @param nframes  - The number of CAN/CANFD frames that should be updated.
+        * @param isCANFD  - Flag for CANFD frames.
+        * @param announce - Flag for immediately sending out the changes once while retaining the cycle.
+        */
         void txSetupUpdateMultipleFrames(struct canfd_frame frames[], int nframes, bool isCANFD, bool announce);
+
+        /**
+        * Removes a cyclic transmission task for the given CAN ID.
+        *
+        * Note: A cyclic transmission task for a sequence of frames can only
+        * be deleted with the CAN ID that was set in the bcm_msg_head.
+        *
+        * @param canID - The CAN ID of the task that should be removed.
+        */
         void txDelete(canid_t canID, bool isCANFD);
 
+        /**
+        * Creates a RX filter for the given CAN ID.
+        * I. e. we get notified on all received frames with this CAN ID.
+        *
+        * @param canID    - The CAN ID that should be added to the RX filter.
+        * @param isCANFD  - Flag for CANFD frames.
+        */
         void rxSetupCanID(canid_t canID, bool isCANFD);
+
+        /**
+        * Creates a RX filter for the CAN ID and the relevant bits of the frame.
+        * I. e. we only get notified on changes for the set bits in the mask.
+        *
+        * @param canID    - The CAN ID that should be added to the RX filter.
+        * @param mask     - The mask for the relevant bits of the frame.
+        * @param isCANFD  - Flag for CANFD frames.
+        */
         void rxSetupMask(canid_t canID, struct canfd_frame mask, bool isCANFD);
+
+        /**
+        * Removes the RX filter for the given CAN ID.
+        *
+        * @param canID   - The CAN ID that should be removed from the RX filter.
+        * @param isCANFD - Flag for CANFD frames.
+        */
         void rxDelete(canid_t canID, bool isCANFD);
 
         // Data members
-        boost::shared_ptr<boost::asio::io_context> ioContext;
-        boost::asio::generic::datagram_protocol::socket bcmSocket;
-        std::array<std::uint8_t, sizeof(struct bcmMsgMultipleFramesCanFD)> rxBuffer{0};
-        std::thread ioContextThread;
+        boost::shared_ptr<boost::asio::io_context> ioContext;                           /**< The io_context used by the BCM socket.           */
+        boost::asio::generic::datagram_protocol::socket bcmSocket;                      /**< The BCM socket that is used to send and receive. */
+        std::array<std::uint8_t, sizeof(struct bcmMsgMultipleFramesCanFD)> rxBuffer{0}; /**< Buffer that stores the received data.            */
+        std::thread ioContextThread;                                                    /**< Thread for the io_context loop.                  */
         CANConnectorConfig config;
 
     };

--- a/Sim_To_DuT_Interface/DuT_Connectors/CANConnector/CANConnector.h
+++ b/Sim_To_DuT_Interface/DuT_Connectors/CANConnector/CANConnector.h
@@ -18,6 +18,7 @@
 #include "../DuTConnector.h"
 #include "InterfaceIndexIO.h"
 #include "CANConnectorConfig.h"
+#include "../../DuTLogger/DuTLogger.h"
 
 // System includes
 #include <thread>
@@ -126,9 +127,10 @@ namespace sim_interface::dut_connector::can{
         /**
         * Creates the BCM socket that is used by the CAN Connector.
         *
+        * @param config - The config of the CAN Connector.
         * @return The BCM socket.
         */
-        boost::asio::generic::datagram_protocol::socket createBcmSocket(const CANConnectorConfig &config);
+        boost::asio::generic::datagram_protocol::socket createBcmSocket(const CANConnectorConfig &canConfig);
 
         /**
         * Starts the io context loop that is running in a dedicated thread.

--- a/Sim_To_DuT_Interface/DuT_Connectors/CANConnector/InterfaceIndexIO.cpp
+++ b/Sim_To_DuT_Interface/DuT_Connectors/CANConnector/InterfaceIndexIO.cpp
@@ -15,6 +15,8 @@
 // Project includes
 #include "InterfaceIndexIO.h"
 
+// System includes
+
 
 /*******************************************************************************
  * FUNCTION DEFINITIONS
@@ -24,29 +26,14 @@ InterfaceIndexIO::InterfaceIndexIO(std::string interfaceName) : ifr(){
     std::strncpy(ifr.ifr_name, interfaceName.c_str(), IF_NAMESIZE);
 }
 
-/**
- * Returns the POSIX ioctl() value for getting the interface index by name.
- *
- * @returns The value of SIOCGIFINDEX
- */
 int InterfaceIndexIO::name(){
     return SIOCGIFINDEX;
 }
 
-/**
- * Returns the ifreq struct that contains the interface name.
- *
- * @return The ifreq with the name
- */
 void* InterfaceIndexIO::data(){
     return &ifr;
 }
 
-/**
- * Returns the resolved interface index.
- *
- * @return The interface index
- */
 int InterfaceIndexIO::index() const{
     return ifr.ifr_ifindex;
 }

--- a/Sim_To_DuT_Interface/DuT_Connectors/CANConnector/InterfaceIndexIO.h
+++ b/Sim_To_DuT_Interface/DuT_Connectors/CANConnector/InterfaceIndexIO.h
@@ -29,13 +29,37 @@
 class InterfaceIndexIO{
 
 public:
+
+    /**
+    * Constructor.
+    *
+    * @param interfaceName - The name of the interface which index should be resolved.
+    */
     explicit InterfaceIndexIO(std::string interfaceName);
+
+    /**
+    * Returns the POSIX ioctl() value for getting the interface index by name.
+    *
+    * @returns The value of SIOCGIFINDEX
+    */
     static int name();
+
+    /**
+    * Returns the ifreq struct that contains the interface name.
+    *
+    * @return The ifreq with the name
+    */
     void* data();
+
+    /**
+    * Returns the resolved interface index.
+    *
+    * @return The resolved interface index.
+    */
     int index() const;
 
 private:
-    ifreq ifr{};
+    ifreq ifr{}; /**< The ifreq struct used for ioctl */
 
 };
 


### PR DESCRIPTION
- NOTE: CAN Connector throws now invalid argument exception if the interface couldn't be resolved correctly. 
You will need at leat a virtual can interface:
1. Check if the socketCAN Kernel modules are loaded
2. Add a vcan interface: sudo ip link add dev vcan0 type vcan
3. Set the interface up and running: sudo ip link set vcan0 up

- Moved function comments from cpp to header
- Replaced std::cout with logMessage calls
- Minor improvements
