### PR TITLE
change timestamp to string formatted with ms resolution

### DIFF
--- a/Dummy_DuT/REST_Dummy_DuT/messages/MessageWithTimestamp.cpp
+++ b/Dummy_DuT/REST_Dummy_DuT/messages/MessageWithTimestamp.cpp
@@ -25,14 +25,25 @@
 
 #include "MessageWithTimestamp.h"
 
+#include <chrono>
+#include <iomanip>
+
 using namespace dummy_dut::rest::model;
 
 namespace dummy_dut::rest::messages {
     MessageWithTimestamp::MessageWithTimestamp(Message *message) {
         this->m_Key = message->getKey();
         this->m_Status = message->getStatus();
-        time_t res = std::time(nullptr);
-        this->timestamp = std::localtime(&res);
+        std::chrono::system_clock::time_point time_point = std::chrono::system_clock::now();
+        std::chrono::system_clock::duration duration = time_point.time_since_epoch();
+        int64_t timestamp = duration.count();
+        std:: time_t  time_t = std::chrono::system_clock::to_time_t (time_point);
+        std:: tm * tm = std::localtime (& time_t );
+
+        std::stringstream ss;
+        ss << std::put_time (tm , "%Y-%m-%d %X") << "." << std::to_string((timestamp / 1000) % 1000000);
+
+        this->timestamp = ss.str();
     }
 
     std::string MessageWithTimestamp::toTableEntry() {
@@ -40,12 +51,12 @@ namespace dummy_dut::rest::messages {
                 <tr>
                     <td>)" + this->m_Key + R"(</td>
                     <td>)" + this->m_Status + R"(</td>
-                    <td>)" + std::asctime(this->timestamp) + R"(</td>
+                    <td>)" + this->timestamp + R"(</td>
                 </tr>)";
     }
 
     std::string MessageWithTimestamp::toTableEntryWithoutNewline() {
-        return "<tr><td>" + this->m_Key + "</td><td>" + this->m_Status + "</td><td>" + std::asctime(this->timestamp) +
+        return "<tr><td>" + this->m_Key + "</td><td>" + this->m_Status + "</td><td>" + this->timestamp +
                "</td></tr>";
     }
 }

--- a/Dummy_DuT/REST_Dummy_DuT/messages/MessageWithTimestamp.h
+++ b/Dummy_DuT/REST_Dummy_DuT/messages/MessageWithTimestamp.h
@@ -50,7 +50,7 @@ namespace dummy_dut::rest::messages {
          */
         std::string toTableEntryWithoutNewline();
 
-        std::tm *timestamp;
+        std::string timestamp;
     };
 }
 

--- a/Sim_To_DuT_Interface/Events/SimEvent.cpp
+++ b/Sim_To_DuT_Interface/Events/SimEvent.cpp
@@ -25,6 +25,8 @@
 #include "SimEvent.h"
 
 #include <utility>
+#include <chrono>
+#include <iomanip>
 #include "EventVisitor.h"
 
 namespace sim_interface {
@@ -35,14 +37,23 @@ namespace sim_interface {
             operation(std::move(operation)),
             value(std::move(value)),
             origin(std::move(origin)) {
-        current = std::time(nullptr);
+        std::chrono::system_clock::time_point time_point = std::chrono::system_clock::now();
+        std::chrono::system_clock::duration duration = time_point.time_since_epoch();
+        int64_t timestamp = duration.count();
+        std:: time_t  time_t = std::chrono::system_clock::to_time_t (time_point);
+        std:: tm * tm = std::localtime (& time_t );
+
+        std::stringstream ss;
+        ss << std::put_time (tm , "%Y-%m-%d %X") << "." << std::to_string((timestamp / 1000) % 1000000);
+
+        current = ss.str();
     }
 
     std::ostream &operator<<(std::ostream &os, const SimEvent &simEvent) {
         os << "Operation: " << simEvent.operation << std::endl;
         os << "Value: " << boost::apply_visitor(EventVisitor(), simEvent.value) << std::endl;
         os << "Origin: " << simEvent.origin << std::endl;
-        os << "Current: " << std::ctime(&simEvent.current) << std::endl;
+        os << "Current: " << simEvent.current << std::endl;
         return os;
     }
 }

--- a/Sim_To_DuT_Interface/Events/SimEvent.h
+++ b/Sim_To_DuT_Interface/Events/SimEvent.h
@@ -33,7 +33,6 @@
 #ifndef INFM_HIL_INTERFACE_SIMEVENT_H
 #define INFM_HIL_INTERFACE_SIMEVENT_H
 
-#include <ctime>
 #include <map>
 #include <string>
 #include <iostream>
@@ -70,7 +69,7 @@ namespace sim_interface {
         /**
          * Time when the event was created.
          */
-        std::time_t current;
+        std::string current;
         /**
          * Origin of the event.
          */

--- a/Sim_To_DuT_Interface/Sim_Communication/SimComHandler.cpp
+++ b/Sim_To_DuT_Interface/Sim_Communication/SimComHandler.cpp
@@ -132,11 +132,7 @@ namespace sim_interface {
         simEventMap["Operation"] = simEvent.operation;
         simEventMap["Value"]     = boost::apply_visitor(EventToSimVisitor(), simEvent.value);
         simEventMap["Origin"]    = simEvent.origin;
-        std::stringstream time;
-        time << simEvent.current;
-        // Time in Secondss
-        // TODO Microsekunden
-        simEventMap["Currrent"]   = time.str();
+        simEventMap["Current"]   = simEvent.current;
         //serialize map
         std::ostringstream ss;
         boost::archive::text_oarchive archive(ss);


### PR DESCRIPTION
Wir wollten ja mal den timestamp mit MS resolution haben. Da ich nirgends was gesehen habe wo der time_t genutzt wurde, statt direkt in einen string konvertiert zu werden, habe ich direkt die String representation gespeichert