### PR TITLE
CAN Connector Cleanup

### DIFF
--- a/Sim_To_DuT_Interface/DuT_Connectors/CANConnector/CANConnector.cpp
+++ b/Sim_To_DuT_Interface/DuT_Connectors/CANConnector/CANConnector.cpp
@@ -1,26 +1,31 @@
-/*******************************************************************************
- \project   INFM_HIL_Interface
- \file      CANConnector.cpp
- \brief     The Connector enables the communication over a CAN/CANFD interface.
-            It builds upon the socketCAN BCM socket and boost::asio.
- \author    Matthias Bank
- \version   1.0.0
- \date      12.11.2021
- ******************************************************************************/
+/**
+ * CAN Connector.
+ * The Connector enables the communication over a CAN/CANFD interface.
+ *
+ * Copyright (C) 2021 Matthias Bank
+ *
+ * This file is part of "Sim To DuT Interface".
+ *
+ * "Sim To DuT Interface" is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * "Sim To DuT Interface" is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with "Sim To DuT Interface".  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * @author Matthias Bank
+ * @version 1.0
+ */
 
-
-/*******************************************************************************
- * INCLUDES
- ******************************************************************************/
 // Project includes
 #include "CANConnector.h"
 
-// System includes
-
-
-/*******************************************************************************
- * FUNCTION DEFINITIONS
- ******************************************************************************/
 namespace sim_interface::dut_connector::can {
 
     CANConnector::CANConnector(
@@ -208,19 +213,16 @@ namespace sim_interface::dut_connector::can {
                                             size_t expectedBytes = 0;
 
                                             if (isCANFD) {
-                                                expectedBytes =
-                                                        head->nframes * sizeof(canfd_frame) + sizeof(bcm_msg_head);
+                                                expectedBytes = head->nframes * sizeof(canfd_frame) + sizeof(bcm_msg_head);
                                             } else {
-                                                expectedBytes =
-                                                        head->nframes * sizeof(can_frame) + sizeof(bcm_msg_head);
+                                                expectedBytes = head->nframes * sizeof(can_frame) + sizeof(bcm_msg_head);
                                             }
 
                                             // Check if we received the whole message
                                             if (receivedBytes == expectedBytes) {
 
                                                 // Get the pointer to the frames and call the next function to process the data
-                                                auto frames = reinterpret_cast<void *>(rxBuffer.data() +
-                                                                                       sizeof(bcm_msg_head));
+                                                auto frames = reinterpret_cast<void *>(rxBuffer.data() + sizeof(bcm_msg_head));
                                                 handleReceivedData(head, frames, head->nframes, isCANFD);
 
                                             } else {
@@ -270,8 +272,7 @@ namespace sim_interface::dut_connector::can {
 
         // Fill out the message
         if (isCANFD) {
-            std::shared_ptr<bcmMsgSingleFrameCanFD> msgCANFD = std::reinterpret_pointer_cast<bcmMsgSingleFrameCanFD>(
-                    msg);
+            std::shared_ptr<bcmMsgSingleFrameCanFD> msgCANFD = std::reinterpret_pointer_cast<bcmMsgSingleFrameCanFD>(msg);
 
             msgCANFD->msg_head.opcode = TX_SEND;
             msgCANFD->msg_head.flags = CAN_FD_FRAME;
@@ -353,8 +354,7 @@ namespace sim_interface::dut_connector::can {
 
         // Fill out the message
         if (isCANFD) {
-            std::shared_ptr<bcmMsgSingleFrameCanFD> msgCANFD = std::reinterpret_pointer_cast<bcmMsgSingleFrameCanFD>(
-                    msg);
+            std::shared_ptr<bcmMsgSingleFrameCanFD> msgCANFD = std::reinterpret_pointer_cast<bcmMsgSingleFrameCanFD>(msg);
 
             msgCANFD->msg_head.opcode = TX_SETUP;
             msgCANFD->msg_head.flags = CAN_FD_FRAME | SETTIMER | STARTTIMER;
@@ -439,8 +439,7 @@ namespace sim_interface::dut_connector::can {
 
         // Fill out the message
         if (isCANFD) {
-            std::shared_ptr<bcmMsgMultipleFramesCanFD> msgCANFD = std::reinterpret_pointer_cast<bcmMsgMultipleFramesCanFD>(
-                    msg);
+            std::shared_ptr<bcmMsgMultipleFramesCanFD> msgCANFD = std::reinterpret_pointer_cast<bcmMsgMultipleFramesCanFD>(msg);
 
             msgCANFD->msg_head.opcode = TX_SETUP;
             msgCANFD->msg_head.flags = CAN_FD_FRAME | SETTIMER | STARTTIMER;
@@ -453,8 +452,7 @@ namespace sim_interface::dut_connector::can {
             size_t arrSize = sizeof(struct canfd_frame) * nframes;
             std::memcpy(msgCANFD->canfdFrames, frames, arrSize);
         } else {
-            std::shared_ptr<bcmMsgMultipleFramesCan> msgCAN = std::reinterpret_pointer_cast<bcmMsgMultipleFramesCan>(
-                    msg);
+            std::shared_ptr<bcmMsgMultipleFramesCan> msgCAN = std::reinterpret_pointer_cast<bcmMsgMultipleFramesCan>(msg);
             auto firstCanFrame = (struct can_frame *) &frames[0];
 
             msgCAN->msg_head.opcode = TX_SETUP;
@@ -522,8 +520,7 @@ namespace sim_interface::dut_connector::can {
         // Fill out the message
         // Note: By combining the flags SETTIMER and STARTTIMER the BCM will start sending the messages immediately
         if (isCANFD) {
-            std::shared_ptr<bcmMsgSingleFrameCanFD> msgCANFD = std::reinterpret_pointer_cast<bcmMsgSingleFrameCanFD>(
-                    msg);
+            std::shared_ptr<bcmMsgSingleFrameCanFD> msgCANFD = std::reinterpret_pointer_cast<bcmMsgSingleFrameCanFD>(msg);
 
             msgCANFD->msg_head.opcode = TX_SETUP;
             msgCANFD->msg_head.flags = CAN_FD_FRAME;
@@ -692,8 +689,7 @@ namespace sim_interface::dut_connector::can {
 
         // Fill out the message
         if (isCANFD) {
-            std::shared_ptr<bcmMsgSingleFrameCanFD> msgCANFD = std::reinterpret_pointer_cast<bcmMsgSingleFrameCanFD>(
-                    msg);
+            std::shared_ptr<bcmMsgSingleFrameCanFD> msgCANFD = std::reinterpret_pointer_cast<bcmMsgSingleFrameCanFD>(msg);
 
             msgCANFD->msg_head.opcode = RX_SETUP;
             msgCANFD->msg_head.flags = CAN_FD_FRAME;
@@ -952,8 +948,3 @@ namespace sim_interface::dut_connector::can {
     }
 
 }
-
-
-/*******************************************************************************
- * END OF FILE
- ******************************************************************************/

--- a/Sim_To_DuT_Interface/DuT_Connectors/CANConnector/CANConnector.h
+++ b/Sim_To_DuT_Interface/DuT_Connectors/CANConnector/CANConnector.h
@@ -1,19 +1,31 @@
-/*******************************************************************************
- \project   INFM_HIL_Interface
- \file      CANConnector.h
- \brief     The CANConnector enables the communication over a CAN interface.
-            It builds upon the socketCAN BCM socket and boost::asio.
- \author    Matthias Bank
- \version   1.0.0
- \date      12.11.2021
- ******************************************************************************/
+/**
+ * CAN Connector.
+ * The Connector enables the communication over a CAN/CANFD interface.
+ *
+ * Copyright (C) 2021 Matthias Bank
+ *
+ * This file is part of "Sim To DuT Interface".
+ *
+ * "Sim To DuT Interface" is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * "Sim To DuT Interface" is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with "Sim To DuT Interface". If not, see <http://www.gnu.org/licenses/>.
+ *
+ * @author Matthias Bank
+ * @version 1.0
+ */
+
 #ifndef SIM_TO_DUT_INTERFACE_CANCONNECTOR_H
 #define SIM_TO_DUT_INTERFACE_CANCONNECTOR_H
 
-
-/*******************************************************************************
- * INCLUDES
- ******************************************************************************/
 // Project includes
 #include "../DuTConnector.h"
 #include "InterfaceIndexIO.h"
@@ -31,22 +43,12 @@
 #include <boost/make_shared.hpp>
 #include <boost/system/error_code.hpp>
 
-
-/*******************************************************************************
- * DEFINES
- ******************************************************************************/
-
 /**
  * Defines how many frames can be put in a bcmMsgMultipleFrames operation.
  * The socketCAN BCM can send up to 256 CAN frames in a sequence in the case
  * of a cyclic TX task configuration. See the socketCAN BCM documentation.
  */
 #define MAXFRAMES 256
-
-
-/*******************************************************************************
- * STRUCTS
- ******************************************************************************/
 
 /**
  * Struct for a BCM message with a single CAN frame.
@@ -80,16 +82,17 @@ struct bcmMsgMultipleFramesCanFD {
     struct canfd_frame canfdFrames[MAXFRAMES];
 };
 
-
-/*******************************************************************************
- * CLASS DECLARATIONS
- ******************************************************************************/
 namespace sim_interface::dut_connector::can {
 
+    /**
+     * <summary>
+     * The Connector enables the communication over a CAN/CANFD interface.
+     * It builds upon the socketCAN BCM socket and boost::asio.
+     * </summary>
+     */
     class CANConnector : public DuTConnector {
 
     public:
-        // Functions members
 
         /**
         * CAN Connector constructor.
@@ -121,10 +124,7 @@ namespace sim_interface::dut_connector::can {
         */
         void handleEventSingle(const SimEvent &event) override;
 
-        // Data members
-
     private:
-        // Function members
 
         /**
         * Creates the BCM socket that is used by the CAN Connector.
@@ -312,22 +312,15 @@ namespace sim_interface::dut_connector::can {
          */
         static std::string convertCanIdToHex(canid_t canID);
 
-        // Data members
         boost::shared_ptr<boost::asio::io_context> ioContext;                           /**< The io_context used by the BCM socket.                 */
         boost::asio::generic::datagram_protocol::socket bcmSocket;                      /**< The BCM socket that is used to send and receive.       */
-        std::array<std::uint8_t, sizeof(struct bcmMsgMultipleFramesCanFD)> rxBuffer{
-                0}; /**< Buffer that stores the received data.                  */
+        std::array<std::uint8_t, sizeof(struct bcmMsgMultipleFramesCanFD)> rxBuffer{0}; /**< Buffer that stores the received data.                  */
         std::thread ioContextThread;                                                    /**< Thread for the io_context loop.                        */
         CANConnectorConfig config;                                                      /**< The config of the CAN connector.                       */
         CANConnectorCodec *codec;                                                       /**< The codec that is used for parsing.                    */
         std::map<std::string, bool> isSetup;                                            /**< Map that keeps track which cyclic operation are setup. */
-
     };
 
 }
 
-
 #endif //SIM_TO_DUT_INTERFACE_CANCONNECTOR_H
-/*******************************************************************************
- * END OF FILE
- ******************************************************************************/

--- a/Sim_To_DuT_Interface/DuT_Connectors/CANConnector/CANConnectorCodec.h
+++ b/Sim_To_DuT_Interface/DuT_Connectors/CANConnector/CANConnectorCodec.h
@@ -1,19 +1,31 @@
-/*******************************************************************************
- \project   INFM_HIL_Interface
- \file      CANConnectorCodec.h
- \brief     The CAN Connector Codec defines the interface that each codec
-            implementation must fulfill.
- \author    Matthias Bank
- \version   1.0.0
- \date      16.12.2021
- ******************************************************************************/
+/**
+ * CAN Connector.
+ * The Connector enables the communication over a CAN/CANFD interface.
+ *
+ * Copyright (C) 2021 Matthias Bank
+ *
+ * This file is part of "Sim To DuT Interface".
+ *
+ * "Sim To DuT Interface" is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * "Sim To DuT Interface" is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with "Sim To DuT Interface". If not, see <http://www.gnu.org/licenses/>.
+ *
+ * @author Matthias Bank
+ * @version 1.0
+ */
+
 #ifndef SIM_TO_DUT_INTERFACE_CANCONNECTORCODEC_H
 #define SIM_TO_DUT_INTERFACE_CANCONNECTORCODEC_H
 
-
-/*******************************************************************************
- * INCLUDES
- ******************************************************************************/
 // Project includes
 #include "../../Events/SimEvent.h"
 #include "InterfaceLogger.h"
@@ -22,23 +34,23 @@
 #include <vector>
 #include <linux/can.h>
 
-
-/*******************************************************************************
- * CLASS DECLARATIONS
- ******************************************************************************/
 namespace sim_interface::dut_connector::can {
 
+    /**
+    * <summary>
+    * The CAN Connector Codec defines the interface that each codec implementation must fulfill.
+    * </summary>
+    */
     class CANConnectorCodec {
 
     public:
-        // Function members
 
         /**
         * Converts an simulation event to a CAN/CANFD payload and determines the sendOperation name.
         *
         * @param event - The simulation event we want to transform into a CAN/CANFD frame payload.
         *
-        * @return The CAN/CANFD frame payload.
+        * @return The CAN/CANFD frame payload and the sendOperation name.
         */
         virtual std::pair<std::vector<__u8>, std::string> convertSimEventToFrame(SimEvent event) = 0;
 
@@ -51,20 +63,8 @@ namespace sim_interface::dut_connector::can {
          * @return The simulation events that were contained in the CAN/CANFD frame.
          */
         virtual std::vector<SimEvent> convertFrameToSimEvent(struct canfd_frame frame, bool isCanfd) = 0;
-
-        // Data members
-
-    private:
-        // Function members
-
-        // Data members
-
     };
 
 }
 
-
 #endif //SIM_TO_DUT_INTERFACE_CANCONNECTORCODEC_H
-/*******************************************************************************
- * END OF FILE
- ******************************************************************************/

--- a/Sim_To_DuT_Interface/DuT_Connectors/CANConnector/CANConnectorCodecFactory.cpp
+++ b/Sim_To_DuT_Interface/DuT_Connectors/CANConnector/CANConnectorCodecFactory.cpp
@@ -1,41 +1,32 @@
-/*******************************************************************************
- \project   INFM_HIL_Interface
- \file      CANConnectorCodecFactory.h
- \brief     Creates the requested CAN codec.
- \author    Matthias Bank, Marco Keul
- \version   1.0.0
- \date      02.12.2021
- ******************************************************************************/
+/**
+ * CAN Connector.
+ * The Connector enables the communication over a CAN/CANFD interface.
+ *
+ * Copyright (C) 2021 Matthias Bank
+ *
+ * This file is part of "Sim To DuT Interface".
+ *
+ * "Sim To DuT Interface" is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * "Sim To DuT Interface" is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with "Sim To DuT Interface". If not, see <http://www.gnu.org/licenses/>.
+ *
+ * @author Marco Keul
+ * @author Matthias Bank
+ * @version 1.0
+ */
 
-
-/*******************************************************************************
- * INCLUDES
- ******************************************************************************/
 // Project includes
 #include "CANConnectorCodecFactory.h"
 
-// Codecs includes
-#include "BmwCodec.h"
-
-
-/*******************************************************************************
- * DEFINES
- ******************************************************************************/
-
-/**
- * The name of the BMW CAN codec.
- */
-#define CODEC_NAME_BMW "BmwCodec"
-
-/**
- * The name of the Suzuki CAN codec.
- */
-#define CODEC_NAME_SUZUKI "SuzukiCodec"
-
-
-/*******************************************************************************
- * FUNCTION DEFINITIONS
- ******************************************************************************/
 namespace sim_interface::dut_connector::can {
 
     CANConnectorCodec *CANConnectorCodecFactory::createCodec(const std::string &codecName) {
@@ -62,8 +53,3 @@ namespace sim_interface::dut_connector::can {
     }
 
 }
-
-
-/*******************************************************************************
- * END OF FILE
- ******************************************************************************/

--- a/Sim_To_DuT_Interface/DuT_Connectors/CANConnector/CANConnectorCodecFactory.h
+++ b/Sim_To_DuT_Interface/DuT_Connectors/CANConnector/CANConnectorCodecFactory.h
@@ -1,34 +1,54 @@
-/*******************************************************************************
- \project   INFM_HIL_Interface
- \file      CANConnectorCodecFactory.h
- \brief     Creates the requested CAN codec.
- \author    Matthias Bank, Marco Keul
- \version   1.0.0
- \date      02.12.2021
- ******************************************************************************/
+/**
+ * CAN Connector.
+ * The Connector enables the communication over a CAN/CANFD interface.
+ *
+ * Copyright (C) 2021 Matthias Bank
+ *
+ * This file is part of "Sim To DuT Interface".
+ *
+ * "Sim To DuT Interface" is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * "Sim To DuT Interface" is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with "Sim To DuT Interface". If not, see <http://www.gnu.org/licenses/>.
+ *
+ * @author Marco Keul
+ * @author Matthias Bank
+ * @version 1.0
+ */
+
 #ifndef SIM_TO_DUT_INTERFACE_CANCONNECTORCODECFACTORY_H
 #define SIM_TO_DUT_INTERFACE_CANCONNECTORCODECFACTORY_H
 
-
-/*******************************************************************************
- * INCLUDES
- ******************************************************************************/
 // Project includes
 #include "CANConnectorCodec.h"
 #include "InterfaceLogger.h"
 
-// System includes
+// Codec includes.
+#include "BmwCodec.h"
 
+/**
+ * The name of the BMW CAN codec.
+ */
+#define CODEC_NAME_BMW "BmwCodec"
 
-/*******************************************************************************
- * CLASS DECLARATIONS
- ******************************************************************************/
 namespace sim_interface::dut_connector::can {
 
+    /**
+    * <summary>
+    * Creates the requested CAN codec.
+    * </summary>
+    */
     class CANConnectorCodecFactory {
 
     public:
-        // Function members
 
         /**
         * Creates the requested CAN codec.
@@ -38,20 +58,8 @@ namespace sim_interface::dut_connector::can {
         * @return The CAN codec.
         */
         static CANConnectorCodec *createCodec(const std::string &codecName);
-
-        // Data members
-
-    private:
-        // Function members
-
-        // Data members
-
     };
 
 }
 
-
 #endif //SIM_TO_DUT_INTERFACE_CANCONNECTORCODECFACTORY_H
-/*******************************************************************************
- * END OF FILE
- ******************************************************************************/

--- a/Sim_To_DuT_Interface/DuT_Connectors/CANConnector/CANConnectorConfig.cpp
+++ b/Sim_To_DuT_Interface/DuT_Connectors/CANConnector/CANConnectorConfig.cpp
@@ -1,22 +1,31 @@
-/*******************************************************************************
- \project   INFM_HIL_Interface
- \file      CANConnectorConfig.cpp
- \brief     The Config for the CANConnector.
- \author    Matthias Bank
- \version   1.0.0
- \date      12.11.2021
- ******************************************************************************/
+/**
+ * CAN Connector.
+ * The Connector enables the communication over a CAN/CANFD interface.
+ *
+ * Copyright (C) 2021 Matthias Bank
+ *
+ * This file is part of "Sim To DuT Interface".
+ *
+ * "Sim To DuT Interface" is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * "Sim To DuT Interface" is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with "Sim To DuT Interface". If not, see <http://www.gnu.org/licenses/>.
+ *
+ * @author Matthias Bank
+ * @version 1.0
+ */
 
-
-/*******************************************************************************
- * INCLUDES
- ******************************************************************************/
+// Project includes
 #include "CANConnectorConfig.h"
 
-
-/*******************************************************************************
- * FUNCTION DEFINITIONS
- ******************************************************************************/
 namespace sim_interface::dut_connector::can {
 
     CANConnectorConfig::CANConnectorConfig(std::string interfaceName,
@@ -51,8 +60,3 @@ namespace sim_interface::dut_connector::can {
     }
 
 }
-
-
-/*******************************************************************************
- * END OF FILE
- ******************************************************************************/

--- a/Sim_To_DuT_Interface/DuT_Connectors/CANConnector/CANConnectorConfig.h
+++ b/Sim_To_DuT_Interface/DuT_Connectors/CANConnector/CANConnectorConfig.h
@@ -1,18 +1,31 @@
-/*******************************************************************************
- \project   INFM_HIL_Interface
- \file      CANConnectorConfig.h
- \brief     The Config for the CANConnector.
- \author    Matthias Bank
- \version   1.0.0
- \date      12.11.2021
- ******************************************************************************/
+/**
+ * CAN Connector.
+ * The Connector enables the communication over a CAN/CANFD interface.
+ *
+ * Copyright (C) 2021 Matthias Bank
+ *
+ * This file is part of "Sim To DuT Interface".
+ *
+ * "Sim To DuT Interface" is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * "Sim To DuT Interface" is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with "Sim To DuT Interface". If not, see <http://www.gnu.org/licenses/>.
+ *
+ * @author Matthias Bank
+ * @version 1.0
+ */
+
 #ifndef SIM_TO_DUT_INTERFACE_CANCONNECTORCONFIG_H
 #define SIM_TO_DUT_INTERFACE_CANCONNECTORCONFIG_H
 
-
-/*******************************************************************************
- * INCLUDES
- ******************************************************************************/
 // Project includes
 #include "../ConnectorConfig.h"
 #include "CANConnectorReceiveOperation.h"
@@ -25,16 +38,16 @@
 #include <string>
 #include <stdexcept>
 
-
-/*******************************************************************************
- * CLASS DECLARATIONS
- ******************************************************************************/
 namespace sim_interface::dut_connector::can {
 
+    /**
+    * <summary>
+    * The config for the CANConnector.
+    * </summary>
+    */
     class CANConnectorConfig : public ConnectorConfig {
 
     public:
-        // Function members
 
         /**
          * Constructor for the CAN Connector configuration.
@@ -56,9 +69,8 @@ namespace sim_interface::dut_connector::can {
                                     std::map<std::string, int> periodicOperations = {},
                                     bool periodicTimerEnabled = false);
 
-        // Data member
-        std::string interfaceName;                                         /**< The name of the interface that should be used.               */
-        std::string codecName;                                             /**< The name of the codec that should be used.                   */
+        std::string interfaceName; /**< The name of the interface that should be used. */
+        std::string codecName;     /**< The name of the codec that should be used.     */
 
         /**
          * This map is used to set up the RX filters of the BCM socket based on the receive operation data
@@ -72,18 +84,8 @@ namespace sim_interface::dut_connector::can {
          * therefore match with a sendOperation entry that is defined in the XML configuration file.
          */
         std::map<std::string, CANConnectorSendOperation> operationToFrame;
-
-    private:
-        // Function members
-
-        // Data member
-
     };
 
 }
 
-
 #endif //SIM_TO_DUT_INTERFACE_CANCONNECTORCONFIG_H
-/*******************************************************************************
- * END OF FILE
- ******************************************************************************/

--- a/Sim_To_DuT_Interface/DuT_Connectors/CANConnector/CANConnectorReceiveOperation.cpp
+++ b/Sim_To_DuT_Interface/DuT_Connectors/CANConnector/CANConnectorReceiveOperation.cpp
@@ -1,23 +1,31 @@
-/*******************************************************************************
- \project   INFM_HIL_Interface
- \file      CANConnectorReceiveOperation.cpp
- \brief     Contains the necessary information to configure a receive operation.
-            Used for the configuration of the CAN Connector.
- \author    Matthias Bank
- \version   1.0.0
- \date      27.11.2021
- ******************************************************************************/
+/**
+ * CAN Connector.
+ * The Connector enables the communication over a CAN/CANFD interface.
+ *
+ * Copyright (C) 2021 Matthias Bank
+ *
+ * This file is part of "Sim To DuT Interface".
+ *
+ * "Sim To DuT Interface" is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * "Sim To DuT Interface" is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with "Sim To DuT Interface". If not, see <http://www.gnu.org/licenses/>.
+ *
+ * @author Matthias Bank
+ * @version 1.0
+ */
 
-
-/*******************************************************************************
- * INCLUDES
- ******************************************************************************/
+// Project includes
 #include "CANConnectorReceiveOperation.h"
 
-
-/*******************************************************************************
- * FUNCTION DEFINITIONS
- ******************************************************************************/
 namespace sim_interface::dut_connector::can {
 
     CANConnectorReceiveOperation::CANConnectorReceiveOperation(std::string operation,
@@ -72,8 +80,3 @@ namespace sim_interface::dut_connector::can {
     }
 
 }
-
-
-/*******************************************************************************
- * END OF FILE
- ******************************************************************************/

--- a/Sim_To_DuT_Interface/DuT_Connectors/CANConnector/CANConnectorReceiveOperation.h
+++ b/Sim_To_DuT_Interface/DuT_Connectors/CANConnector/CANConnectorReceiveOperation.h
@@ -1,20 +1,30 @@
-/*******************************************************************************
- \project   INFM_HIL_Interface
- \file      CANConnectorReceiveOperation.h
- \brief     Contains the necessary information to configure a receive operation.
-            Used for the configuration of the CAN Connector.
- \author    Matthias Bank
- \version   1.0.0
- \date      27.11.2021
- ******************************************************************************/
+/**
+ * CAN Connector.
+ * The Connector enables the communication over a CAN/CANFD interface.
+ *
+ * Copyright (C) 2021 Matthias Bank
+ *
+ * This file is part of "Sim To DuT Interface".
+ *
+ * "Sim To DuT Interface" is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * "Sim To DuT Interface" is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with "Sim To DuT Interface". If not, see <http://www.gnu.org/licenses/>.
+ *
+ * @author Matthias Bank
+ * @version 1.0
+ */
+
 #ifndef SIM_TO_DUT_INTERFACE_CANCONNECTORRECEIVEOPERATION_H
 #define SIM_TO_DUT_INTERFACE_CANCONNECTORRECEIVEOPERATION_H
-
-
-/*******************************************************************************
- * INCLUDES
- ******************************************************************************/
-// Project includes
 
 // System includes
 #include <string>
@@ -23,16 +33,17 @@
 #include <linux/can.h>
 #include <linux/can/bcm.h>
 
-
-/*******************************************************************************
- * CLASS DECLARATIONS
- ******************************************************************************/
 namespace sim_interface::dut_connector::can {
 
+    /**
+    * <summary>
+    * Contains the necessary information to configure a receive operation for
+    * the configuration of the CAN Connector.
+    * </summary>
+    */
     class CANConnectorReceiveOperation {
 
     public:
-        // Functions members
 
         /**
          * Constructor for an receive operation.
@@ -49,24 +60,13 @@ namespace sim_interface::dut_connector::can {
                                      int maskLength = 0,
                                      __u8 *maskData = nullptr);
 
-        // Data members
         std::string operation;            /**< The operation name.                                                       */
         bool isCANFD;                     /**< Flag for CANFD frames.                                                    */
         bool hasMask;                     /**< Flag if a mask should be used to filter for content changes in the frames.*/
         int maskLength;                   /**< The length of the mask data.                                              */
         struct canfd_frame mask = {0};    /**< The mask that should be used to filter for content changes in the frames. */
-
-    private:
-        // Functions members
-
-        // Data members
-
     };
 
 }
 
-
 #endif //SIM_TO_DUT_INTERFACE_CANCONNECTORRECEIVEOPERATION_H
-/*******************************************************************************
- * END OF FILE
- ******************************************************************************/

--- a/Sim_To_DuT_Interface/DuT_Connectors/CANConnector/CANConnectorSendOperation.cpp
+++ b/Sim_To_DuT_Interface/DuT_Connectors/CANConnector/CANConnectorSendOperation.cpp
@@ -1,24 +1,31 @@
-/*******************************************************************************
- \project   INFM_HIL_Interface
- \file      CANConnectorSendOperation.cpp
- \brief     Contains the necessary information to configure a send operation.
-            Used for the configuration of the CAN Connector.
- \author    Matthias Bank
- \version   1.0.0
- \date      27.11.2021
- ******************************************************************************/
+/**
+ * CAN Connector.
+ * The Connector enables the communication over a CAN/CANFD interface.
+ *
+ * Copyright (C) 2021 Matthias Bank
+ *
+ * This file is part of "Sim To DuT Interface".
+ *
+ * "Sim To DuT Interface" is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * "Sim To DuT Interface" is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with "Sim To DuT Interface". If not, see <http://www.gnu.org/licenses/>.
+ *
+ * @author Matthias Bank
+ * @version 1.0
+ */
 
-
-/*******************************************************************************
- * INCLUDES
- ******************************************************************************/
 // Project includes
 #include "CANConnectorSendOperation.h"
 
-
-/*******************************************************************************
- * FUNCTION DEFINITIONS
- ******************************************************************************/
 namespace sim_interface::dut_connector::can {
 
     CANConnectorSendOperation::CANConnectorSendOperation(canid_t canID,
@@ -71,8 +78,3 @@ namespace sim_interface::dut_connector::can {
     }
 
 }
-
-
-/*******************************************************************************
- * END OF FILE
- ******************************************************************************/

--- a/Sim_To_DuT_Interface/DuT_Connectors/CANConnector/CANConnectorSendOperation.h
+++ b/Sim_To_DuT_Interface/DuT_Connectors/CANConnector/CANConnectorSendOperation.h
@@ -1,20 +1,30 @@
-/*******************************************************************************
- \project   INFM_HIL_Interface
- \file      CANConnectorSendOperation.h
- \brief     Contains the necessary information to configure a send operation.
-            Used for the configuration of the CAN Connector.
- \author    Matthias Bank
- \version   1.0.0
- \date      27.11.2021
- ******************************************************************************/
+/**
+ * CAN Connector.
+ * The Connector enables the communication over a CAN/CANFD interface.
+ *
+ * Copyright (C) 2021 Matthias Bank
+ *
+ * This file is part of "Sim To DuT Interface".
+ *
+ * "Sim To DuT Interface" is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * "Sim To DuT Interface" is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with "Sim To DuT Interface". If not, see <http://www.gnu.org/licenses/>.
+ *
+ * @author Matthias Bank
+ * @version 1.0
+ */
+
 #ifndef SIM_TO_DUT_INTERFACE_CANCONNECTORSENDOPERATION_H
 #define SIM_TO_DUT_INTERFACE_CANCONNECTORSENDOPERATION_H
-
-
-/*******************************************************************************
- * INCLUDES
- ******************************************************************************/
-// Project includes
 
 // System includes
 #include <string>
@@ -22,16 +32,17 @@
 #include <linux/can.h>
 #include <linux/can/bcm.h>
 
-
-/*******************************************************************************
- * CLASS DECLARATIONS
- ******************************************************************************/
 namespace sim_interface::dut_connector::can {
 
+    /**
+     * <summary>
+     * Contains the necessary information to configure a send operation for
+     * the configuration of the CAN Connector.
+     * </summary>
+     */
     class CANConnectorSendOperation {
 
     public:
-        // Functions members
 
         /**
          * Constructor
@@ -60,18 +71,8 @@ namespace sim_interface::dut_connector::can {
         __u32 count;                    /**< Number of times the frame is send with the first interval. */
         struct bcm_timeval ival1;       /**< First Interval.                                            */
         struct bcm_timeval ival2;       /**< Second Interval.                                           */
-
-    private:
-        // Functions members
-
-        // Data members
-
     };
 
 }
 
-
 #endif //SIM_TO_DUT_INTERFACE_CANCONNECTORSENDOPERATION_H
-/*******************************************************************************
- * END OF FILE
- ******************************************************************************/

--- a/Sim_To_DuT_Interface/DuT_Connectors/CANConnector/InterfaceIndexIO.cpp
+++ b/Sim_To_DuT_Interface/DuT_Connectors/CANConnector/InterfaceIndexIO.cpp
@@ -1,44 +1,47 @@
-/*******************************************************************************
- \project   INFM_HIL_Interface
- \file      InterfaceIndexIO.cpp
- \brief     I/O control command class for getting the interface index.
-            For further information see boost asio io_control.
- \author    Matthias Bank
- \version   1.0.0
- \date      12.11.2021
- ******************************************************************************/
+/**
+ * CAN Connector.
+ * The Connector enables the communication over a CAN/CANFD interface.
+ *
+ * Copyright (C) 2021 Matthias Bank
+ *
+ * This file is part of "Sim To DuT Interface".
+ *
+ * "Sim To DuT Interface" is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * "Sim To DuT Interface" is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with "Sim To DuT Interface". If not, see <http://www.gnu.org/licenses/>.
+ *
+ * @author Matthias Bank
+ * @version 1.0
+ */
 
-
-/*******************************************************************************
- * INCLUDES
- ******************************************************************************/
 // Project includes
 #include "InterfaceIndexIO.h"
 
-// System includes
+namespace sim_interface::dut_connector::can {
 
+    InterfaceIndexIO::InterfaceIndexIO(std::string interfaceName) : ifr() {
+        std::strncpy(ifr.ifr_name, interfaceName.c_str(), IF_NAMESIZE);
+    }
 
-/*******************************************************************************
- * FUNCTION DEFINITIONS
- ******************************************************************************/
+    int InterfaceIndexIO::name() {
+        return SIOCGIFINDEX;
+    }
 
-InterfaceIndexIO::InterfaceIndexIO(std::string interfaceName) : ifr() {
-    std::strncpy(ifr.ifr_name, interfaceName.c_str(), IF_NAMESIZE);
+    void *InterfaceIndexIO::data() {
+        return &ifr;
+    }
+
+    int InterfaceIndexIO::index() const {
+        return ifr.ifr_ifindex;
+    }
+
 }
-
-int InterfaceIndexIO::name() {
-    return SIOCGIFINDEX;
-}
-
-void *InterfaceIndexIO::data() {
-    return &ifr;
-}
-
-int InterfaceIndexIO::index() const {
-    return ifr.ifr_ifindex;
-}
-
-
-/*******************************************************************************
- * END OF FILE
- ******************************************************************************/

--- a/Sim_To_DuT_Interface/DuT_Connectors/CANConnector/InterfaceIndexIO.h
+++ b/Sim_To_DuT_Interface/DuT_Connectors/CANConnector/InterfaceIndexIO.h
@@ -1,20 +1,30 @@
-/*******************************************************************************
- \project   INFM_HIL_Interface
- \file      InterfaceIndexIO.h
- \brief     I/O control command class for getting the interface index.
-            For further information see boost asio io_control.
- \author    Matthias Bank
- \version   1.0.0
- \date      12.11.2021
- ******************************************************************************/
+/**
+ * CAN Connector.
+ * The Connector enables the communication over a CAN/CANFD interface.
+ *
+ * Copyright (C) 2021 Matthias Bank
+ *
+ * This file is part of "Sim To DuT Interface".
+ *
+ * "Sim To DuT Interface" is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * "Sim To DuT Interface" is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with "Sim To DuT Interface". If not, see <http://www.gnu.org/licenses/>.
+ *
+ * @author Matthias Bank
+ * @version 1.0
+ */
+
 #ifndef SIM_TO_DUT_INTERFACE_INTERFACEINDEXIO_H
 #define SIM_TO_DUT_INTERFACE_INTERFACEINDEXIO_H
-
-
-/*******************************************************************************
- * INCLUDES
- ******************************************************************************/
-// Project includes
 
 // System includes
 #include <string>
@@ -22,49 +32,51 @@
 #include <net/if.h>
 #include <sys/ioctl.h>
 
-
-/*******************************************************************************
- * CLASS DECLARATIONS
- ******************************************************************************/
-class InterfaceIndexIO {
-
-public:
+namespace sim_interface::dut_connector::can {
 
     /**
-    * Constructor.
-    *
-    * @param interfaceName - The name of the interface which index should be resolved.
-    */
-    explicit InterfaceIndexIO(std::string interfaceName);
+     * <summary>
+     * I/O control command class for getting the interface index.
+     * For further information see boost asio io_control.
+     * </summary>
+     */
+    class InterfaceIndexIO {
 
-    /**
-    * Returns the POSIX ioctl() value for getting the interface index by name.
-    *
-    * @returns The value of SIOCGIFINDEX
-    */
-    static int name();
+    public:
 
-    /**
-    * Returns the ifreq struct that contains the interface name.
-    *
-    * @return The ifreq with the name
-    */
-    void *data();
+        /**
+        * Constructor.
+        *
+        * @param interfaceName - The name of the interface which index should be resolved.
+        */
+        explicit InterfaceIndexIO(std::string interfaceName);
 
-    /**
-    * Returns the resolved interface index.
-    *
-    * @return The resolved interface index.
-    */
-    int index() const;
+        /**
+        * Returns the POSIX ioctl() value for getting the interface index by name.
+        *
+        * @returns The value of SIOCGIFINDEX
+        */
+        static int name();
 
-private:
-    ifreq ifr{}; /**< The ifreq struct used for ioctl */
+        /**
+        * Returns the ifreq struct that contains the interface name.
+        *
+        * @return The ifreq with the name
+        */
+        void *data();
 
-};
+        /**
+        * Returns the resolved interface index.
+        *
+        * @return The resolved interface index.
+        */
+        int index() const;
 
+    private:
+
+        ifreq ifr{}; /**< The ifreq struct used for ioctl */
+    };
+
+}
 
 #endif //SIM_TO_DUT_INTERFACE_INTERFACEINDEXIO_H
-/*******************************************************************************
- * END OF FILE
- ******************************************************************************/


### PR DESCRIPTION
- Adjusted the style to the rest of the project
  - Changed Header
  - Removed section comments
  - Removed unused private fields, include comments
- Added summarys for the doxygen documentation
- Added missing namespace for the InterfaceIndexIO